### PR TITLE
Support Xcode 10

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,5 @@
 github "AliSoftware/OHHTTPStubs" "826a9217fcd468220d154ed0075cbc1a20d0c5c9"
-github "BoltsFramework/Bolts-ObjC" "1.9.0"
+github "BoltsFramework/Bolts-ObjC" "1b247a7047546e9eecd36387a121977b53e2ea43"
 github "erikdoe/ocmock" "c4be5d9d9238fcd10449424f651fba2b7aff87c0"
 github "facebook/Tweaks" "858506f594462073a1dee82a4c8254e23d10aef0"
 github "facebook/xctool" "fe6fb5dfab112cfbb0a2fbda1f6a528abbe0d272"

--- a/FBSDKCoreKit/FBSDKCoreKit.xcodeproj/project.pbxproj
+++ b/FBSDKCoreKit/FBSDKCoreKit.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		0384CED0208E606A0013D404 /* FBSDKAccessTokenExpirer.m in Sources */ = {isa = PBXBuildFile; fileRef = 033429B120894D4700C94913 /* FBSDKAccessTokenExpirer.m */; };
 		0384CED1208E606B0013D404 /* FBSDKAccessTokenExpirer.m in Sources */ = {isa = PBXBuildFile; fileRef = 033429B120894D4700C94913 /* FBSDKAccessTokenExpirer.m */; };
 		2A3DA4161CB4C0F600339BD4 /* FBSDKAppLinkUtilityTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 2A3DA4151CB4C0F600339BD4 /* FBSDKAppLinkUtilityTests.m */; };
+		3F83E1E6215BFE1C00CD7C71 /* FBSDKUserDataStore.m in Sources */ = {isa = PBXBuildFile; fileRef = F9169B832155A03C00FA1789 /* FBSDKUserDataStore.m */; };
 		4AF47CF31F42468E00A57A67 /* FBSDKDeviceUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 4AF47CF11F42468D00A57A67 /* FBSDKDeviceUtilities.m */; };
 		4AF47CF41F42468E00A57A67 /* FBSDKDeviceUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 4AF47CF11F42468D00A57A67 /* FBSDKDeviceUtilities.m */; };
 		4AF47CF51F42468E00A57A67 /* FBSDKDeviceUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 4AF47CF21F42468D00A57A67 /* FBSDKDeviceUtilities.h */; };
@@ -2737,6 +2738,7 @@
 				81B71D3B1D19C87400933E93 /* FBSDKGraphRequestConnection.m in Sources */,
 				81B71D3C1D19C87400933E93 /* FBSDKAccessTokenCacheV3.m in Sources */,
 				81B71D3D1D19C87400933E93 /* FBSDKAppEvents.m in Sources */,
+				3F83E1E6215BFE1C00CD7C71 /* FBSDKUserDataStore.m in Sources */,
 				81B71D3E1D19C87400933E93 /* _FBSDKTemporaryErrorRecoveryAttempter.m in Sources */,
 				81B71D3F1D19C87400933E93 /* FBSDKBridgeAPIProtocolNativeV1.m in Sources */,
 				81B71D401D19C87400933E93 /* FBSDKWebDialogView.m in Sources */,


### PR DESCRIPTION
- [x] sign [contributor license agreement](https://developers.facebook.com/opensource/cla)
- [x] submit against our `dev` branch, not `master`.
 I cannot see `dev` branch anymore
- [x] describe the change (for example, what happens before the change, and after the change)

This PR supports building the project with Xcode10.
- Apply https://github.com/BoltsFramework/Bolts-ObjC/pull/324
- Also fixes the issue that `FBSDKUserDataStore` is not added to `FBSDKCoreKit-Dynamic`.