### PR TITLE
hot fix for 308 login error (challenge with + symbol)

### DIFF
--- a/FBSDKLoginKit/FBSDKLoginKit/FBSDKLoginManager.m
+++ b/FBSDKLoginKit/FBSDKLoginKit/FBSDKLoginManager.m
@@ -230,7 +230,7 @@ typedef NS_ENUM(NSInteger, FBSDKLoginManagerState) {
   if (expectChallenge) {
     // Perform this check early so we be sure to clear expected challenge in all cases.
     NSString *challengeReceived = parameters.challenge;
-    NSString *challengeExpected = [self loadExpectedChallenge];
+    NSString *challengeExpected = [[self loadExpectedChallenge] stringByReplacingOccurrencesOfString:@"+" withString:@" "];
     if (![challengeExpected isEqualToString:challengeReceived]) {
       challengePassed = NO;
     }


### PR DESCRIPTION
Original issue: https://github.com/facebook/facebook-sdk-swift/issues/286

Discussion: challengeReceived will never contain '+' symbol, reason:
in FBSDKUtility.m line 65-67, URLDecode explicitly replaces '+' signs with ' '.
Do the same for stored in keychain challengeExpected.
Related to special symbol '+'  in url encoded string.

- [+] sign [contributor license agreement](https://developers.facebook.com/opensource/cla)
- [+] describe the change (for example, what happens before the change, and after the change)

Before the change: login fails with 308 error if challenge contains `+` sign. 
After the change: no random login failures. 
