### PR TITLE
Elements of containers need to be whitelisted as well for NSSecureCoding

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/Internal/ServerConfiguration/FBSDKErrorConfiguration.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/Internal/ServerConfiguration/FBSDKErrorConfiguration.m
@@ -150,7 +150,9 @@ static NSString *const kErrorCategoryLogin = @"login";
 
 - (id)initWithCoder:(NSCoder *)decoder
 {
-  NSDictionary *configurationDictionary = [decoder decodeObjectOfClass:[NSDictionary class] forKey:FBSDKERRORCONFIGURATION_DICTIONARY_KEY];
+  NSSet *classes = [[NSSet alloc] initWithObjects:[NSDictionary class], [FBSDKErrorRecoveryConfiguration class], nil];
+  NSDictionary *configurationDictionary = [decoder decodeObjectOfClasses:classes
+                                                                  forKey:FBSDKERRORCONFIGURATION_DICTIONARY_KEY];
   return [self initWithDictionary:configurationDictionary];
 }
 


### PR DESCRIPTION
Secure decoding will now succeed with this fix.