### PR TITLE
Use secure decoding & prefer APIs using NSError over NSException

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/Internal/ServerConfiguration/FBSDKServerConfigurationManager.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/Internal/ServerConfiguration/FBSDKServerConfigurationManager.m
@@ -128,12 +128,18 @@ typedef NS_OPTIONS(NSUInteger, FBSDKServerConfigurationManagerAppEventsFeatures)
       NSData *data = [defaults objectForKey:defaultsKey];
       if ([data isKindOfClass:[NSData class]]) {
         // decode the configuration
-        FBSDKServerConfiguration *serverConfiguration = [NSKeyedUnarchiver unarchiveObjectWithData:data];
-        if ([serverConfiguration isKindOfClass:[FBSDKServerConfiguration class]]) {
-          // ensure that the configuration points to the current appID
-          if ([serverConfiguration.appID isEqualToString:appID]) {
-            _serverConfiguration = serverConfiguration;
+        FBSDKServerConfiguration *serverConfiguration;
+        if (@available(iOS 11, *)) {
+          serverConfiguration = [NSKeyedUnarchiver unarchivedObjectOfClass:FBSDKServerConfiguration.class fromData:data error:NULL];
+        } else {
+          serverConfiguration = [NSKeyedUnarchiver unarchiveTopLevelObjectWithData:data error:NULL];
+          if (serverConfiguration != nil && ![serverConfiguration isKindOfClass:[FBSDKServerConfiguration class]]) {
+            serverConfiguration = nil;
           }
+        }
+        // ensure that the configuration points to the current appID
+        if (serverConfiguration != nil && [serverConfiguration.appID isEqualToString:appID]) {
+          _serverConfiguration = serverConfiguration;
         }
       }
     }


### PR DESCRIPTION
I've only tested it with some data I happened to have on my device. With the faulty data I tested with, this new code would (correctly & reliably) return nil. For some reason, it would unreliably throw an NSException before (for me anyway).

You may want to test that all data can successfully decode with this before merging this PR. 

Related to #925.