### PR TITLE
Fixes some bugs in FBSDKButton.m

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/FBSDKButton.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/FBSDKButton.m
@@ -185,10 +185,10 @@
 
 - (void)configureButton
 {
-  [self configureWithIcon:[[self class] defaultIcon]
+  [self configureWithIcon:[self defaultIcon]
                     title:nil
-          backgroundColor:[[self class] defaultBackgroundColor]
-         highlightedColor:[[self class] defaultHighlightedColor]];
+          backgroundColor:[self defaultBackgroundColor]
+         highlightedColor:[self defaultHighlightedColor]];
 }
 
 - (void)configureWithIcon:(FBSDKIcon *)icon


### PR DESCRIPTION
defaultIcon is instance method, but call `[[self class] defaultIcon]`

Thanks for proposing a pull request.

To help us review the request, please complete the following:

- [ ] sign [contributor license agreement](https://developers.facebook.com/opensource/cla)
- [ ] describe the change (for example, what happens before the change, and after the change)
