### PR TITLE
FB Login fix in case challenge string has '+' in it

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/FBSDKUtility.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/FBSDKUtility.m
@@ -62,12 +62,7 @@
 
 + (NSString *)URLDecode:(NSString *)value
 {
-  value = [value stringByReplacingOccurrencesOfString:@"+" withString:@" "];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  value = [value stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
-#pragma clang diagnostic pop
-  return value;
+  return value.stringByRemovingPercentEncoding;
 }
 
 #pragma clang diagnostic push

--- a/FBSDKLoginKit/FBSDKLoginKit/FBSDKLoginManager.m
+++ b/FBSDKLoginKit/FBSDKLoginKit/FBSDKLoginManager.m
@@ -230,7 +230,7 @@ typedef NS_ENUM(NSInteger, FBSDKLoginManagerState) {
   if (expectChallenge) {
     // Perform this check early so we be sure to clear expected challenge in all cases.
     NSString *challengeReceived = parameters.challenge;
-    NSString *challengeExpected = [[self loadExpectedChallenge] stringByReplacingOccurrencesOfString:@"+" withString:@" "];
+    NSString *challengeExpected = [self loadExpectedChallenge];
     if (![challengeExpected isEqualToString:challengeReceived]) {
       challengePassed = NO;
     }


### PR DESCRIPTION
Please refer to [this](https://github.com/facebook/facebook-objc-sdk/pull/922) issue 

I have been having issue with fb login, 2 out of 5 times. On searching and debugging I found it was issue with '+' symbol (and may be others) in challenge string that is stored locally and the one delivered from server. I figured out that the recent code revert to old commit re-introduced the issue. And for some reason I was facing this issue even before that, probably I didn't clean by build folder. However, now I have made changes and tested it and it seems to work fine. Please go through the change and see if it will impact any other part of sdk, which I think will not be the case. 
For me these changes resolve the fb login issue (error code 308)
