### PR TITLE
Fix the wrong URL encode due to missing characters

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/FBSDKUtility.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/FBSDKUtility.m
@@ -77,7 +77,7 @@
   return (__bridge_transfer NSString *)CFURLCreateStringByAddingPercentEscapes(NULL,
                                                                                (CFStringRef)value,
                                                                                NULL, // characters to leave unescaped
-                                                                               CFSTR(":!*();@/&?+$,='"),
+                                                                               CFSTR(":!*();@/&?+$,='%#[]{}"),
                                                                                kCFStringEncodingUTF8);
 }
 #pragma clang diagnostic pop


### PR DESCRIPTION
Fix the wrong URL encode due to missing characters such as (%#[]{})

**Environment:**
- Xcode Version: 10.0 (10A255)
- Swift Version: 4.2 
- Cocoapods version 1.6.0.beta.2

**Used Pods:**
```
# Obj-C
pod 'FBSDKCoreKit', '4.39.1'
pod 'FBSDKShareKit', '4.39.1'
    
# Swift
pod 'FacebookCore', '0.5.0'
pod 'FacebookShare', '0.5.0'
```

I tried to open a native share dialog but it shows this error

> FBSDKLog: unregisterTransientObject:FBSDKShareDialog count is 0. This may indicate a bug in the FBSDK. Please file a report to developers.facebook.com/bugs if you encounter any problems. Thanks

**This code to reproduce the issue:**
```
let url = URL(string: "https://www.facebook.com")
 let content = FBSDKShareLinkContent.init()
content.contentURL = url
content.addParameters([:], bridgeOptions: FBSDKShareBridgeOptions.init(rawValue: 0))
let dialog = FBSDKShareDialog.init()
dialog.fromViewController = self
dialog.shareContent = content
dialog.delegate = self
dialog.mode = FBSDKShareDialogMode.native
dialog.show()
```


**The Issue:** 
- The wrong URL encode for JSON string value within the query parameters

**The solution:**
- Add some characters to be encoded
