### PR TITLE
Fix tvOS builds

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/FBSDKApplicationDelegate.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/FBSDKApplicationDelegate.m
@@ -266,12 +266,14 @@ typedef void (^FBSDKAuthenticationCompletionHandler)(NSURL *_Nullable callbackUR
 
 - (void)applicationDidBecomeActive:(NSNotification *)notification
 {
+#if !TARGET_OS_TV
     if (!_safariViewController) {
         UIViewController *topController = FBSDKInternalUtility.topMostViewController;
         if ([topController isKindOfClass:[SFSafariViewController class]]) {
             _safariViewController = topController;
         }
     }
+#endif
 
     // Auto log basic events in case autoLogAppEventsEnabled is set
     if (FBSDKSettings.isAutoLogAppEventsEnabled) {


### PR DESCRIPTION
Summary: SFSafariViewController is not available on tvOS, so add check

Differential Revision: D14056303
