### PR TITLE
Add NS_ASSUME_NONNULL to FBSDKUserDataStore.h

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/Internal/AppEvents/FBSDKUserDataStore.h
+++ b/FBSDKCoreKit/FBSDKCoreKit/Internal/AppEvents/FBSDKUserDataStore.h
@@ -18,6 +18,8 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface FBSDKUserDataStore : NSObject
 
 + (void)initStore;
@@ -38,3 +40,5 @@
 + (NSString *) getHashedUserData;
 
 @end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
This was causing the build to fail on the Xcode 10.2 beta

Thanks for proposing a pull request.

To help us review the request, please complete the following:

- [x] sign [contributor license agreement](https://developers.facebook.com/opensource/cla)
- [x] describe the change (for example, what happens before the change, and after the change)
