### PR TITLE
Make sure completePendingOpenURLBlock is always called

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/FBSDKApplicationDelegate.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/FBSDKApplicationDelegate.m
@@ -199,10 +199,12 @@ typedef void (^FBSDKAuthenticationCompletionHandler)(NSURL *_Nullable callbackUR
         [_safariViewController.presentingViewController dismissViewControllerAnimated:YES
                                                                            completion:completePendingOpenURLBlock];
         _safariViewController = nil;
-    } else if (@available(iOS 11.0, *)) {
-        if (_authenticationSession != nil) {
-            [_authenticationSession cancel];
-            _authenticationSession = nil;
+    } else {
+        if (@available(iOS 11.0, *)) {
+            if (_authenticationSession != nil) {
+                [_authenticationSession cancel];
+                _authenticationSession = nil;
+            }
         }
         completePendingOpenURLBlock();
     }


### PR DESCRIPTION
Summary: iOS 8 does not have SafariViewController available. Instead, when Safari is used for auth, it switches to the Safari app and returns, but this case is not properly handled at the moment. The completion block is never called and instead the LoginManager returns `.cancelled` result.

Reviewed By: codytwinton

Differential Revision: D14195829

fbshipit-source-id: 55b42596925dfa85785ec5ef75397fac00c3945d

Thanks for proposing a pull request.

To help us review the request, please complete the following:

- [x] sign [contributor license agreement](https://developers.facebook.com/opensource/cla)
- [x] describe the change (for example, what happens before the change, and after the change)
