### PR TITLE
Fix importing header by relative directory

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/Internal/UI/FBSDKUIUtility.h
+++ b/FBSDKCoreKit/FBSDKCoreKit/Internal/UI/FBSDKUIUtility.h
@@ -18,7 +18,7 @@
 
 #import <UIKit/UIKit.h>
 
-#import "../FBSDKMath.h"
+#import "FBSDKMath.h"
 
 /**
   Insets a CGSize with the insets in a UIEdgeInsets.


### PR DESCRIPTION
This fixes build error when building with other build system than Xcode. The compiler should be able to find the header within the module.