### PR TITLE
Update the FBSDKCoreKit podspec to take into account the new modulemap file

### DIFF
--- a/FBSDKCoreKit.podspec
+++ b/FBSDKCoreKit.podspec
@@ -36,7 +36,7 @@ Pod::Spec.new do |s|
                     'FBSDKCoreKit/FBSDKCoreKit/Internal/**/*']
 
   s.subspec 'Basics' do |ss|
-    ss.source_files = 'FBSDKCoreKit/FBSDKCoreKit/Basics/*',
+    ss.source_files = 'FBSDKCoreKit/FBSDKCoreKit/Basics/*.{h,m}',
                       'FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.{h,m}'
     ss.public_header_files = 'FBSDKCoreKit/FBSDKCoreKit/Basics/*.h'
   end


### PR DESCRIPTION
## Summary
With the introduction of the `FBSDKCoreKit.modulemap` to the Basics folder, after updating to the newer version of the pod, I keep getting the following warning:
<img width="470" alt="Screen Shot 2019-05-01 at 5 51 06 pm" src="https://user-images.githubusercontent.com/4775087/57009482-384d3e00-6c3a-11e9-95cb-80ed1ed3e795.png">
As it is not a source file, Xcode doesn't need to analyse because it won't be able to compile it.

## Changes
- Restricted the type of source files to `.h` and `.m`

Thanks for proposing a pull request.

To help us review the request, please complete the following:

- [x] sign [contributor license agreement](https://developers.facebook.com/opensource/cla)
- [x] describe the change (for example, what happens before the change, and after the change)