### PR TITLE
Update Carthage to create a single archive

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -273,12 +273,7 @@ build_sdk() {
     carthage build --no-skip-current
 
     if [ "${1:-}" == "--archive" ]; then
-      for kit in "${SDK_KITS[@]}"; do
-        if [ -d "$SDK_DIR"/Carthage/Build/iOS/"$kit".framework ] \
-          || [ -d "$SDK_DIR"/Carthage/Build/tvOS/"$kit".framework ]; then
-          carthage archive "$kit" --output Carthage/Release/
-        fi
-      done
+      carthage archive --output Carthage/Release/
     fi
   }
 


### PR DESCRIPTION
Carthage expects a single .zip file containing all frameworks for all platforms. The current method means that only the FBSDKCoreKit framework will be downloaded (when not using `--no-use-binaries`), this should allow them to all be downloaded automatically by Carthage.

---

Thanks for proposing a pull request.

To help us review the request, please complete the following:

- [x] sign [contributor license agreement](https://developers.facebook.com/opensource/cla)
- [x] describe the change (for example, what happens before the change, and after the change)
