### PR TITLE
Fix integer precision loss warning

### DIFF
--- a/FBSDKShareKit/FBSDKShareKit/FBSDKAppInviteContent.m
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKAppInviteContent.m
@@ -158,7 +158,7 @@
   [encoder encodeObject:_appInvitePreviewImageURL forKey:FBSDK_APP_INVITE_CONTENT_PREVIEW_IMAGE_KEY];
   [encoder encodeObject:_promotionCode forKey:FBSDK_APP_INVITE_CONTENT_PROMO_CODE_KEY];
   [encoder encodeObject:_promotionText forKey:FBSDK_APP_INVITE_CONTENT_PROMO_TEXT_KEY];
-  [encoder encodeInt:_destination forKey:FBSDK_APP_INVITE_CONTENT_DESTINATION_KEY];
+  [encoder encodeInt:(int)_destination forKey:FBSDK_APP_INVITE_CONTENT_DESTINATION_KEY];
 }
 
 #pragma mark - NSCopying


### PR DESCRIPTION
Fixes the warning:`facebook/facebook-objc-sdk/FBSDKShareKit/FBSDKShareKit/FBSDKAppInviteContent.m:161:22: Implicit conversion loses integer precision: 'FBSDKAppInviteDestination' (aka 'enum FBSDKAppInviteDestination') to 'int'`

Thanks for proposing a pull request.

To help us review the request, please complete the following:

- [x] sign [contributor license agreement](https://developers.facebook.com/opensource/cla)
- [x] describe the change (for example, what happens before the change, and after the change)
