### PR TITLE
Fix incorrect method declaration

### DIFF
--- a/FBSDKLoginKit/FBSDKLoginKit/Internal/FBSDKLoginManagerLogger.h
+++ b/FBSDKLoginKit/FBSDKLoginKit/Internal/FBSDKLoginManagerLogger.h
@@ -28,7 +28,7 @@ NS_SWIFT_NAME(LoginManagerLogger)
 + (FBSDKLoginManagerLogger *)loggerFromParameters:(NSDictionary *)parameters;
 
 - (instancetype)init NS_UNAVAILABLE;
-- (instancetype)new NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
 
 - (instancetype)initWithLoggingToken:(NSString *)loggingToken NS_DESIGNATED_INITIALIZER;
 


### PR DESCRIPTION
Thanks for proposing a pull request.

To help us review the request, please complete the following:

- [x] sign [contributor license agreement](https://developers.facebook.com/opensource/cla)
- [x] describe the change (for example, what happens before the change, and after the change)

Before the change, you could be able to instantiate an `FBSDKLoginManagerLogger` object using `[FBSDKLoginManagerLogger new]`.