### PR TITLE
Fix build error when using UIKit for Mac (Project Catalyst)

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKImageDownloader.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKImageDownloader.m
@@ -38,7 +38,7 @@ static NSString *const kCachedResponseUserInfoKeyTimestamp = @"timestamp";
 - (instancetype)init
 {
   if ((self = [super init])) {
-#if TARGET_OS_UIKITFORMAC
+#if TARGET_OS_MACCATALYST
     _urlCache = [[NSURLCache alloc] initWithMemoryCapacity:1024*1024*8
                                               diskCapacity:1024*1024*100
                                               directoryURL:[NSURL URLWithString:kImageDirectory]];

--- a/FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKImageDownloader.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKImageDownloader.m
@@ -38,9 +38,21 @@ static NSString *const kCachedResponseUserInfoKeyTimestamp = @"timestamp";
 - (instancetype)init
 {
   if ((self = [super init])) {
+#if TARGET_OS_UIKITFORMAC
     _urlCache = [[NSURLCache alloc] initWithMemoryCapacity:1024*1024*8
                                               diskCapacity:1024*1024*100
-                                                  diskPath:kImageDirectory];
+                                              directoryURL:[NSURL URLWithString:kImageDirectory]];
+#else
+    if (@available(iOS 13.0, *)) {
+      _urlCache = [[NSURLCache alloc] initWithMemoryCapacity:1024*1024*8
+                                                diskCapacity:1024*1024*100
+                                                directoryURL:[NSURL URLWithString:kImageDirectory]];
+    } else {
+      _urlCache = [[NSURLCache alloc] initWithMemoryCapacity:1024*1024*8
+                                                diskCapacity:1024*1024*100
+                                                    diskPath:kImageDirectory];
+    }
+#endif
   }
   return self;
 }


### PR DESCRIPTION
Thanks for proposing a pull request.

To help us review the request, please complete the following:

- [x] sign [contributor license agreement](https://developers.facebook.com/opensource/cla)
- [x] describe the change (for example, what happens before the change, and after the change)

As the error states:

> 'initWithMemoryCapacity:diskCapacity:diskPath:' is unavailable: not available on macCatalyst

and it will also be deprecated in iOS 13.