### PR TITLE
Fix build errors when using UIKit for Mac (Project Catalyst)

### DIFF
--- a/FBSDKShareKit/FBSDKShareKit/FBSDKShareAPI.m
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKShareAPI.m
@@ -18,7 +18,7 @@
 
 #import "FBSDKShareAPI.h"
 
-#if !TARGET_OS_TV
+#if !TARGET_OS_TV && !TARGET_OS_UIKITFORMAC
 #import <AssetsLibrary/AssetsLibrary.h>
 #endif
 
@@ -49,7 +49,7 @@ static NSMutableArray *g_pendingFBSDKShareAPI;
 
 @implementation FBSDKShareAPI {
   NSFileHandle *_fileHandle;
-#if !TARGET_OS_TV
+#if !TARGET_OS_TV && !TARGET_OS_UIKITFORMAC
   ALAssetRepresentation *_assetRepresentation;
 #endif
 }
@@ -80,7 +80,7 @@ static NSMutableArray *g_pendingFBSDKShareAPI;
 
 #pragma mark - Object Lifecycle
 
-#if !TARGET_OS_TV
+#if !TARGET_OS_TV && !TARGET_OS_UIKITFORMAC
 + (ALAssetsLibrary *)defaultAssetsLibrary {
   static dispatch_once_t pred = 0;
   static ALAssetsLibrary *library = nil;
@@ -441,7 +441,7 @@ static NSMutableArray *g_pendingFBSDKShareAPI;
     [videoUploader start];
     return YES;
   } else if (videoURL) {
-#if TARGET_OS_TV
+#if TARGET_OS_TV || TARGET_OS_UIKITFORMAC
     return NO;
 #else
     if (![self _addToPendingShareAPI]) {
@@ -798,7 +798,7 @@ static NSMutableArray *g_pendingFBSDKShareAPI;
   @synchronized(g_pendingFBSDKShareAPI) {
     [g_pendingFBSDKShareAPI removeObject:self];
     _fileHandle = nil;
-#if !TARGET_OS_TV
+#if !TARGET_OS_TV && !TARGET_OS_UIKITFORMAC
     _assetRepresentation = nil;
 #endif
   }
@@ -817,7 +817,7 @@ static NSMutableArray *g_pendingFBSDKShareAPI;
     }
     return videoChunkData;
   }
-#if !TARGET_OS_TV
+#if !TARGET_OS_TV && !TARGET_OS_UIKITFORMAC
   else if (_assetRepresentation) {
     NSMutableData *data = [NSMutableData dataWithLength:chunkSize];
     NSError *error;

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKShareAPI.m
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKShareAPI.m
@@ -18,7 +18,7 @@
 
 #import "FBSDKShareAPI.h"
 
-#if !TARGET_OS_TV && !TARGET_OS_UIKITFORMAC
+#if !TARGET_OS_TV && !TARGET_OS_MACCATALYST
 #import <AssetsLibrary/AssetsLibrary.h>
 #endif
 
@@ -49,7 +49,7 @@ static NSMutableArray *g_pendingFBSDKShareAPI;
 
 @implementation FBSDKShareAPI {
   NSFileHandle *_fileHandle;
-#if !TARGET_OS_TV && !TARGET_OS_UIKITFORMAC
+#if !TARGET_OS_TV && !TARGET_OS_MACCATALYST
   ALAssetRepresentation *_assetRepresentation;
 #endif
 }
@@ -80,7 +80,7 @@ static NSMutableArray *g_pendingFBSDKShareAPI;
 
 #pragma mark - Object Lifecycle
 
-#if !TARGET_OS_TV && !TARGET_OS_UIKITFORMAC
+#if !TARGET_OS_TV && !TARGET_OS_MACCATALYST
 + (ALAssetsLibrary *)defaultAssetsLibrary {
   static dispatch_once_t pred = 0;
   static ALAssetsLibrary *library = nil;
@@ -441,7 +441,7 @@ static NSMutableArray *g_pendingFBSDKShareAPI;
     [videoUploader start];
     return YES;
   } else if (videoURL) {
-#if TARGET_OS_TV || TARGET_OS_UIKITFORMAC
+#if TARGET_OS_TV || TARGET_OS_MACCATALYST
     return NO;
 #else
     if (![self _addToPendingShareAPI]) {
@@ -798,7 +798,7 @@ static NSMutableArray *g_pendingFBSDKShareAPI;
   @synchronized(g_pendingFBSDKShareAPI) {
     [g_pendingFBSDKShareAPI removeObject:self];
     _fileHandle = nil;
-#if !TARGET_OS_TV && !TARGET_OS_UIKITFORMAC
+#if !TARGET_OS_TV && !TARGET_OS_MACCATALYST
     _assetRepresentation = nil;
 #endif
   }
@@ -817,7 +817,7 @@ static NSMutableArray *g_pendingFBSDKShareAPI;
     }
     return videoChunkData;
   }
-#if !TARGET_OS_TV && !TARGET_OS_UIKITFORMAC
+#if !TARGET_OS_TV && !TARGET_OS_MACCATALYST
   else if (_assetRepresentation) {
     NSMutableData *data = [NSMutableData dataWithLength:chunkSize];
     NSError *error;


### PR DESCRIPTION
Thanks for proposing a pull request.

To help us review the request, please complete the following:

- [x] sign [contributor license agreement](https://developers.facebook.com/opensource/cla)
- [x] describe the change (for example, what happens before the change, and after the change)

As the error states:

> AssetsLibrary is deprecated and is not available when building for Mac Catalyst. Consider migrating to Photos instead, or use `#if !TARGET_OS_UIKITFORMAC` to conditionally import this framework.

The migration could be done in a separate PR, as I don't have the time nor the required knowledge for it.