### PR TITLE
Cleanup: There is only one login behavior available

### DIFF
--- a/FBSDKLoginKit/FBSDKLoginKit.xcodeproj/project.pbxproj
+++ b/FBSDKLoginKit/FBSDKLoginKit.xcodeproj/project.pbxproj
@@ -75,7 +75,6 @@
 		0BD1F3502093A1A0005109EC /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0BD1F34C2093A1A0005109EC /* CoreGraphics.framework */; };
 		0BD1F3522093A1A3005109EC /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0BD1F3512093A1A3005109EC /* UIKit.framework */; };
 		0BD1F3532093A1AE005109EC /* FBSDKCoreKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8118B6851D0A5B9400962084 /* FBSDKCoreKit.framework */; };
-		5E309CA3228F2580007B532E /* FBSDKLoginCompletionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5E309CA2228F2580007B532E /* FBSDKLoginCompletionTests.m */; };
 		6B34A7ED1ABA4E7300AF9858 /* FBSDKLoginManagerLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 6B34A7EC1ABA4E6B00AF9858 /* FBSDKLoginManagerLogger.m */; };
 		6B4453551A8AF2B9004C4437 /* Accounts.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6B4453531A8AF299004C4437 /* Accounts.framework */; };
 		6B5D2DEA1A8D91B200D3EF09 /* FBSDKLoginError.m in Sources */ = {isa = PBXBuildFile; fileRef = 6B5D2DE91A8D91B200D3EF09 /* FBSDKLoginError.m */; };
@@ -271,7 +270,6 @@
 		0B9DBF52207C07C600662776 /* FBSDKLoginKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FBSDKLoginKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		0BD1F34C2093A1A0005109EC /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS11.3.sdk/System/Library/Frameworks/CoreGraphics.framework; sourceTree = DEVELOPER_DIR; };
 		0BD1F3512093A1A3005109EC /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS11.3.sdk/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
-		5E309CA2228F2580007B532E /* FBSDKLoginCompletionTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBSDKLoginCompletionTests.m; sourceTree = "<group>"; };
 		6B34A7EB1ABA4E6B00AF9858 /* FBSDKLoginManagerLogger.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FBSDKLoginManagerLogger.h; sourceTree = "<group>"; };
 		6B34A7EC1ABA4E6B00AF9858 /* FBSDKLoginManagerLogger.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBSDKLoginManagerLogger.m; sourceTree = "<group>"; };
 		6B4453531A8AF299004C4437 /* Accounts.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Accounts.framework; path = System/Library/Frameworks/Accounts.framework; sourceTree = SDKROOT; };
@@ -583,7 +581,6 @@
 				6B6276321A8C1BBF0030FEBD /* FBSDKLoginUtilityTests.h */,
 				6B6276331A8C1BBF0030FEBD /* FBSDKLoginUtilityTests.m */,
 				9D641F831A7B69160048F563 /* FBSDKLoginManagerTests.m */,
-				5E309CA2228F2580007B532E /* FBSDKLoginCompletionTests.m */,
 				9D9DB8E91A114E500086167B /* Supporting Files */,
 			);
 			path = FBSDKLoginKitTests;
@@ -1028,7 +1025,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				9D641F841A7B69160048F563 /* FBSDKLoginManagerTests.m in Sources */,
-				5E309CA3228F2580007B532E /* FBSDKLoginCompletionTests.m in Sources */,
 				6B6276341A8C1BBF0030FEBD /* FBSDKLoginUtilityTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/FBSDKLoginKit/FBSDKLoginKit/FBSDKLoginButton.h
+++ b/FBSDKLoginKit/FBSDKLoginKit/FBSDKLoginButton.h
@@ -71,7 +71,8 @@ NS_SWIFT_NAME(FBLoginButton)
 /**
   Gets or sets the login behavior to use
  */
-@property (assign, nonatomic) FBSDKLoginBehavior loginBehavior;
+@property (assign, nonatomic) FBSDKLoginBehavior loginBehavior
+DEPRECATED_MSG_ATTRIBUTE("All login flows utilize the browser. This will be removed in the next major release");
 
 /*!
  @abstract The permissions to request.

--- a/FBSDKLoginKit/FBSDKLoginKit/FBSDKLoginManager.h
+++ b/FBSDKLoginKit/FBSDKLoginKit/FBSDKLoginManager.h
@@ -88,7 +88,8 @@ typedef NS_ENUM(NSUInteger, FBSDKLoginBehavior)
     which present specialized SafariViewControllers. Falls back to plain SFSafariViewController (iOS 9 and 10) or Safari (iOS 8).
    */
   FBSDKLoginBehaviorBrowser = 0,
-} NS_SWIFT_NAME(LoginBehavior);
+} NS_SWIFT_NAME(LoginBehavior)
+DEPRECATED_MSG_ATTRIBUTE("All login flows utilize the browser. This will be removed in the next major release");
 
 /**
   `FBSDKLoginManager` provides methods for logging the user in and out.
@@ -119,7 +120,8 @@ NS_SWIFT_NAME(LoginManager)
 /**
   the login behavior
  */
-@property (assign, nonatomic) FBSDKLoginBehavior loginBehavior;
+@property (assign, nonatomic) FBSDKLoginBehavior loginBehavior
+DEPRECATED_MSG_ATTRIBUTE("All login flows utilize the browser. This will be removed in the next major release");
 
 /**
  Logs the user in or authorizes additional permissions.

--- a/FBSDKLoginKit/FBSDKLoginKit/FBSDKLoginManager.m
+++ b/FBSDKLoginKit/FBSDKLoginKit/FBSDKLoginManager.m
@@ -346,7 +346,7 @@ typedef NS_ENUM(NSInteger, FBSDKLoginManagerState) {
 
   [_logger startSessionForLoginManager:self];
 
-  [self logInWithBehavior:self.loginBehavior];
+  [self logIn];
 }
 
 - (void)reauthorizeDataAccess:(FBSDKLoginManagerLoginResultBlock)handler
@@ -358,10 +358,10 @@ typedef NS_ENUM(NSInteger, FBSDKLoginManagerState) {
   _requestedPermissions = [NSSet set];
   self.authType = FBSDKLoginAuthTypeReauthorize;
   [_logger startSessionForLoginManager:self];
-  [self logInWithBehavior:self.loginBehavior];
+  [self logIn];
 }
 
-- (void)logInWithBehavior:(FBSDKLoginBehavior)loginBehavior
+- (void)logIn
 {
   FBSDKServerConfiguration *serverConfiguration = [FBSDKServerConfigurationManager cachedServerConfiguration];
   NSDictionary *loginParams = [self logInParametersWithPermissions:_requestedPermissions serverConfiguration:serverConfiguration];

--- a/FBSDKLoginKit/FBSDKLoginKit/Internal/FBSDKLoginCompletion.m
+++ b/FBSDKLoginKit/FBSDKLoginKit/Internal/FBSDKLoginCompletion.m
@@ -214,7 +214,7 @@ static void FBSDKLoginRequestMeAndPermissions(FBSDKLoginCompletionParameters *pa
   }
 
   if ([FBSDKBridgeAPI sharedInstance].isActive) {
-    [loginManager logInWithBehavior:FBSDKLoginBehaviorBrowser];
+    [loginManager logIn];
   } else {
     // The application is active but due to notification ordering the FBSDKApplicationDelegate
     // doesn't know it yet. Wait one more turn of the run loop.

--- a/FBSDKLoginKit/FBSDKLoginKit/Internal/FBSDKLoginManager+Internal.h
+++ b/FBSDKLoginKit/FBSDKLoginKit/Internal/FBSDKLoginManager+Internal.h
@@ -42,7 +42,7 @@ NS_SWIFT_NAME(BrowserLoginSuccessBlock);
 
 // available to internal types to trigger login without checking read/publish mixtures.
 - (void)logInWithPermissions:(NSSet *)permissions handler:(FBSDKLoginManagerLoginResultBlock)handler;
-- (void)logInWithBehavior:(FBSDKLoginBehavior)loginBehavior;
+- (void)logIn;
 
 // made available for testing only
 - (NSDictionary *)logInParametersWithPermissions:(NSSet *)permissions serverConfiguration:(FBSDKServerConfiguration *)serverConfiguration;

--- a/FBSDKLoginKit/FBSDKLoginKit/Internal/FBSDKLoginManagerLogger.m
+++ b/FBSDKLoginKit/FBSDKLoginKit/Internal/FBSDKLoginManagerLogger.m
@@ -93,15 +93,8 @@ static NSString *const FBSDKLoginManagerLoggerTryBrowser = @"trySafariAuth";
 {
   BOOL isReauthorize = ([FBSDKAccessToken currentAccessToken] != nil);
   BOOL willTryNative = NO;
-  BOOL willTryBrowser = NO;
-  NSString *behaviorString = nil;
-
-  switch (loginManager.loginBehavior) {
-    case FBSDKLoginBehaviorBrowser:
-      willTryBrowser = YES;
-      behaviorString = @"FBSDKLoginBehaviorBrowser";
-      break;
-  }
+  BOOL willTryBrowser = YES;
+  NSString *behaviorString = @"FBSDKLoginBehaviorBrowser";
 
   [_extras addEntriesFromDictionary:@{
     FBSDKLoginManagerLoggerTryNative : @(willTryNative),

--- a/FBSDKLoginKit/FBSDKLoginKitTests/FBSDKLoginManagerTests.m
+++ b/FBSDKLoginKit/FBSDKLoginKitTests/FBSDKLoginManagerTests.m
@@ -308,7 +308,7 @@ static NSString *const kFakeChallenge = @"a =bcdef";
   FBSDKLoginManager *manager = [OCMockObject partialMockForObject:[FBSDKLoginManager new]];
   [[[(id)manager stub] andDo:^(NSInvocation *invocation) {
     loginCount++;
-  }] logInWithBehavior:FBSDKLoginBehaviorBrowser];
+  }] logIn];
   [manager logInWithPermissions:@[@"public_profile"] fromViewController:nil handler:^(FBSDKLoginManagerLoginResult *result, NSError *error) {
     // This will never be called
     XCTFail(@"Should not be called");


### PR DESCRIPTION
Thanks for proposing a pull request.

To help us review the request, please complete the following:

- [x] sign [contributor license agreement](https://developers.facebook.com/opensource/cla)
- [x] describe the change (for example, what happens before the change, and after the change)

Deprecation of `FBSDKLoginBehavior`. All login flows utilize the browser as deep-linking directly to Facebook is discouraged. Native login is still possible but will happen via a step where a browser is invoked first. The ability to pass the option is present on `FBSDKLoginManager` and `FBSDKLoginButton` but the property is ignored. This marks that property as deprecated on both.
