### PR TITLE
CI Updates for Swift Targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ jobs:
       osx_image: xcode10.2
     - stage: test
       name: Pod Lint - Xcode 10.3
-      osx_image: xcode10.2
+      osx_image: xcode10.3
       script: sh scripts/run.sh lint cocoapods --allow-warnings
     # - stage: tag
     #   name: Tag Version

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ jobs:
       name: Swift - Xcode 10.3
       osx_image: xcode10.3
       env:
-        - XCODE_SDK=iOS 12.2
+        - XCODE_SDK=iphonesimulator12.4
         - XCODE_SCHEME=SwiftKits
     - stage: test
       name: Carthage - Xcode 10.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,12 +43,18 @@ jobs:
         - XCODE_SDK=iphonesimulator11.4
         - XCODE_SCHEME=BuildAllKits
     - stage: test
+      name: Swift - Xcode 10.3
+      osx_image: xcode10.3
+      env:
+        - XCODE_SDK=iOS 12.2
+        - XCODE_SCHEME=SwiftKits
+    - stage: test
       name: Carthage - Xcode 10.2
       osx_image: xcode10.2
-    # - stage: test # Re-enable after 5.0 releases
-    #   name: Pod Lint - Xcode 10.2
-    #   osx_image: xcode10.2
-    #   script: sh scripts/run.sh lint cocoapods --allow-warnings
+    - stage: test
+      name: Pod Lint - Xcode 10.3
+      osx_image: xcode10.2
+      script: sh scripts/run.sh lint cocoapods --allow-warnings
     # - stage: tag
     #   name: Tag Version
     #   osx_image: xcode10.2
@@ -69,8 +75,23 @@ jobs:
           all_branches: true
           tags: true
     - stage: release
+      name: GitHub Release Swift
+      osx_image: xcode10.3
+      script: sh scripts/run.sh release github swift
+      deploy:
+        provider: releases
+        skip_cleanup: true
+        api_key: $GITHUB_ACCESS_TOKEN
+        file: build/Release/*
+        file_glob: true
+        name: Facebook SDK $TRAVIS_TAG
+        body: Consult Changelog $TRAVIS_TAG
+        on:
+          all_branches: true
+          tags: true
+    - stage: release
       name: Publish Cocoapods
-      osx_image: xcode10.2
+      osx_image: xcode10.3
       script: sh scripts/run.sh release cocoapods --allow-warnings
 
 before_install: sh scripts/travis/before_install.sh

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,19 +1,19 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (3.0.0)
+    CFPropertyList (3.0.1)
     activesupport (4.2.11.1)
       i18n (~> 0.7)
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     atomos (0.1.3)
-    claide (1.0.2)
-    cocoapods (1.6.1)
+    claide (1.0.3)
+    cocoapods (1.7.5)
       activesupport (>= 4.0.2, < 5)
       claide (>= 1.0.2, < 2.0)
-      cocoapods-core (= 1.6.1)
-      cocoapods-deintegrate (>= 1.0.2, < 2.0)
+      cocoapods-core (= 1.7.5)
+      cocoapods-deintegrate (>= 1.0.3, < 2.0)
       cocoapods-downloader (>= 1.2.2, < 2.0)
       cocoapods-plugins (>= 1.0.0, < 2.0)
       cocoapods-search (>= 1.0.0, < 2.0)
@@ -22,13 +22,13 @@ GEM
       cocoapods-try (>= 1.1.0, < 2.0)
       colored2 (~> 3.1)
       escape (~> 0.0.4)
-      fourflusher (>= 2.2.0, < 3.0)
+      fourflusher (>= 2.3.0, < 3.0)
       gh_inspector (~> 1.0)
       molinillo (~> 0.6.6)
       nap (~> 1.0)
       ruby-macho (~> 1.4)
-      xcodeproj (>= 1.8.1, < 2.0)
-    cocoapods-core (1.6.1)
+      xcodeproj (>= 1.10.0, < 2.0)
+    cocoapods-core (1.7.5)
       activesupport (>= 4.0.2, < 6)
       fuzzy_match (~> 2.0.4)
       nap (~> 1.0)
@@ -38,7 +38,7 @@ GEM
       nap
     cocoapods-search (1.0.0)
     cocoapods-stats (1.1.0)
-    cocoapods-trunk (1.3.1)
+    cocoapods-trunk (1.4.0)
       nap (>= 0.8, < 2.0)
       netrc (~> 0.11)
     cocoapods-try (1.1.0)
@@ -46,7 +46,7 @@ GEM
     concurrent-ruby (1.1.5)
     escape (0.0.4)
     ffi (1.10.0)
-    fourflusher (2.2.0)
+    fourflusher (2.3.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
     i18n (0.9.5)
@@ -86,7 +86,7 @@ GEM
       thread_safe (~> 0.1)
     xcinvoke (0.3.0)
       liferaft (~> 0.0.6)
-    xcodeproj (1.8.2)
+    xcodeproj (1.12.0)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
       claide (>= 1.0.2, < 2.0)
@@ -105,4 +105,4 @@ DEPENDENCIES
   xcpretty
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -325,8 +325,15 @@ lint_sdk() {
         continue
       fi
 
+      local dependent_spec
+
       set +e
-      if ! pod lib lint "$spec" "$@"; then
+      # Needs to include dependent specs for some pods so that we can
+      # test linting without relying on specs being pushed to the trunk
+      if [ "$spec" != FBSDKCoreKit.podspec ]; then
+        dependent_spec="--include-podspecs=FBSDKCoreKit.podspec"
+      fi
+      if ! pod lib lint "$spec" $dependent_spec "$@"; then
         pod_lint_failures+=("$spec")
       fi
       set -e


### PR DESCRIPTION
Summary: This updates the build scripts to allow for building and releasing the Swift targets of the SDK. Additionally uncomments the 'Pod Lint' job of the 'test' phase and updates the cocoapods release phase to use Xcode 10.3 so that it will build the Swift subspecs.

Reviewed By: jingping2015

Differential Revision: D17308486

