### PR TITLE
Deprecating messenger sharing

### DIFF
--- a/FBSDKShareKit/FBSDKShareKit/FBSDKMessageDialog.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKMessageDialog.h
@@ -19,6 +19,7 @@
 #import <Foundation/Foundation.h>
 
 #import <FBSDKShareKit/FBSDKSharing.h>
+#import <FBSDKShareKit/FBSDKShareConstants.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -38,7 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
  - Any other types that are not one of the four supported types listed above
  */
 NS_SWIFT_NAME(MessageDialog)
-DEPRECATED_MSG_ATTRIBUTE("Sharing to Messenger via the SDK is unsupported. https://developers.facebook.com/docs/messenger-platform/changelog/#20190610. Sharing should be performed by the native share sheet.")
+DEPRECATED_FOR_MESSENGER
 @interface FBSDKMessageDialog : NSObject <FBSDKSharingDialog>
 
 /**

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKMessageDialog.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKMessageDialog.h
@@ -38,6 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
  - Any other types that are not one of the four supported types listed above
  */
 NS_SWIFT_NAME(MessageDialog)
+DEPRECATED_MSG_ATTRIBUTE("Sharing to Messenger via the SDK is unsupported. https://developers.facebook.com/docs/messenger-platform/changelog/#20190610. Sharing should be performed by the native share sheet.")
 @interface FBSDKMessageDialog : NSObject <FBSDKSharingDialog>
 
 /**

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKMessageDialog.m
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKMessageDialog.m
@@ -31,7 +31,10 @@
 
 #define FBSDK_MESSAGE_DIALOG_APP_SCHEME @"fb-messenger-share-api"
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 @implementation FBSDKMessageDialog
+#pragma clang diagnostic pop
 
 #pragma mark - Class Methods
 

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKSendButton.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKSendButton.h
@@ -20,6 +20,7 @@
 
 #import <FBSDKCoreKit/FBSDKButton.h>
 
+#import <FBSDKShareKit/FBSDKShareConstants.h>
 #import <FBSDKShareKit/FBSDKSharingButton.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -30,7 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
  Tapping the receiver will invoke the FBSDKShareDialog with the attached shareContent.  If the dialog cannot
  be shown, the button will be disable.
  */
-DEPRECATED_MSG_ATTRIBUTE("Sharing to Messenger via the SDK is unsupported. https://developers.facebook.com/docs/messenger-platform/changelog/#20190610. Sharing should be performed by the native share sheet.")
+DEPRECATED_FOR_MESSENGER
 NS_SWIFT_NAME(FBSendButton)
 @interface FBSDKSendButton : FBSDKButton <FBSDKSharingButton>
 

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKSendButton.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKSendButton.h
@@ -30,6 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
  Tapping the receiver will invoke the FBSDKShareDialog with the attached shareContent.  If the dialog cannot
  be shown, the button will be disable.
  */
+DEPRECATED_MSG_ATTRIBUTE("Sharing to Messenger via the SDK is unsupported. https://developers.facebook.com/docs/messenger-platform/changelog/#20190610. Sharing should be performed by the native share sheet.")
 NS_SWIFT_NAME(FBSendButton)
 @interface FBSDKSendButton : FBSDKButton <FBSDKSharingButton>
 

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKSendButton.m
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKSendButton.m
@@ -25,7 +25,10 @@
 @interface FBSDKSendButton () <FBSDKButtonImpressionTracking>
 @end
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 @implementation FBSDKSendButton
+#pragma clang diagnostic pop
 {
   FBSDKMessageDialog *_dialog;
 }

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKShareConstants.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKShareConstants.h
@@ -18,6 +18,10 @@
 
 #import <Foundation/Foundation.h>
 
+#ifndef DEPRECATED_FOR_MESSENGER
+#define DEPRECATED_FOR_MESSENGER DEPRECATED_MSG_ATTRIBUTE("Sharing to Messenger via the SDK is unsupported. https://developers.facebook.com/docs/messenger-platform/changelog/#20190610. Sharing should be performed by the native share sheet.")
+#endif
+
 NS_ASSUME_NONNULL_BEGIN
 
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKShareMessengerActionButton.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKShareMessengerActionButton.h
@@ -25,6 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  A base interface for Messenger share action buttons.
  */
+DEPRECATED_MSG_ATTRIBUTE("Sharing to Messenger via the SDK is unsupported. https://developers.facebook.com/docs/messenger-platform/changelog/#20190610. Sharing should be performed by the native share sheet.")
 NS_SWIFT_NAME(ShareMessengerActionButton)
 @protocol FBSDKShareMessengerActionButton <FBSDKCopying, NSSecureCoding>
 

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKShareMessengerActionButton.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKShareMessengerActionButton.h
@@ -19,13 +19,14 @@
 #import <Foundation/Foundation.h>
 
 #import <FBSDKCoreKit/FBSDKCopying.h>
+#import <FBSDKShareKit/FBSDKShareConstants.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 /**
  A base interface for Messenger share action buttons.
  */
-DEPRECATED_MSG_ATTRIBUTE("Sharing to Messenger via the SDK is unsupported. https://developers.facebook.com/docs/messenger-platform/changelog/#20190610. Sharing should be performed by the native share sheet.")
+DEPRECATED_FOR_MESSENGER
 NS_SWIFT_NAME(ShareMessengerActionButton)
 @protocol FBSDKShareMessengerActionButton <FBSDKCopying, NSSecureCoding>
 

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKShareMessengerGenericTemplateContent.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKShareMessengerGenericTemplateContent.h
@@ -19,12 +19,13 @@
 #import <Foundation/Foundation.h>
 
 #import <FBSDKShareKit/FBSDKSharingContent.h>
+#import <FBSDKShareKit/FBSDKShareConstants.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 @class FBSDKShareMessengerGenericTemplateElement;
 
-DEPRECATED_MSG_ATTRIBUTE("Sharing to Messenger via the SDK is unsupported. https://developers.facebook.com/docs/messenger-platform/changelog/#20190610. Sharing should be performed by the native share sheet.")
+DEPRECATED_FOR_MESSENGER
 typedef NS_ENUM(NSUInteger, FBSDKShareMessengerGenericTemplateImageAspectRatio) {
   FBSDKShareMessengerGenericTemplateImageAspectRatioHorizontal = 0,
   FBSDKShareMessengerGenericTemplateImageAspectRatioSquare
@@ -36,7 +37,7 @@ typedef NS_ENUM(NSUInteger, FBSDKShareMessengerGenericTemplateImageAspectRatio) 
  See https://developers.facebook.com/docs/messenger-platform/send-messages/template/generic
  for more details.
  */
-DEPRECATED_MSG_ATTRIBUTE("Sharing to Messenger via the SDK is unsupported. https://developers.facebook.com/docs/messenger-platform/changelog/#20190610. Sharing should be performed by the native share sheet.")
+DEPRECATED_FOR_MESSENGER
 NS_SWIFT_NAME(ShareMessengerGenericTemplateContent)
 @interface FBSDKShareMessengerGenericTemplateContent : NSObject <FBSDKSharingContent>
 

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKShareMessengerGenericTemplateContent.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKShareMessengerGenericTemplateContent.h
@@ -24,6 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @class FBSDKShareMessengerGenericTemplateElement;
 
+DEPRECATED_MSG_ATTRIBUTE("Sharing to Messenger via the SDK is unsupported. https://developers.facebook.com/docs/messenger-platform/changelog/#20190610. Sharing should be performed by the native share sheet.")
 typedef NS_ENUM(NSUInteger, FBSDKShareMessengerGenericTemplateImageAspectRatio) {
   FBSDKShareMessengerGenericTemplateImageAspectRatioHorizontal = 0,
   FBSDKShareMessengerGenericTemplateImageAspectRatioSquare
@@ -35,6 +36,7 @@ typedef NS_ENUM(NSUInteger, FBSDKShareMessengerGenericTemplateImageAspectRatio) 
  See https://developers.facebook.com/docs/messenger-platform/send-messages/template/generic
  for more details.
  */
+DEPRECATED_MSG_ATTRIBUTE("Sharing to Messenger via the SDK is unsupported. https://developers.facebook.com/docs/messenger-platform/changelog/#20190610. Sharing should be performed by the native share sheet.")
 NS_SWIFT_NAME(ShareMessengerGenericTemplateContent)
 @interface FBSDKShareMessengerGenericTemplateContent : NSObject <FBSDKSharingContent>
 

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKShareMessengerGenericTemplateContent.m
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKShareMessengerGenericTemplateContent.m
@@ -30,6 +30,7 @@ static NSString *const kGenericTemplateIsSharableKey = @"isSharable";
 static NSString *const kGenericTemplateImageAspectRatioKey = @"imageAspectRatio";
 static NSString *const kGenericTemplateElementKey = @"element";
 
+DEPRECATED_MSG_ATTRIBUTE("Sharing to Messenger via the SDK is unsupported. https://developers.facebook.com/docs/messenger-platform/changelog/#20190610. Sharing should be performed by the native share sheet.")
 static NSString *_ImageAspectRatioString(FBSDKShareMessengerGenericTemplateImageAspectRatio imageAspectRatio)
 {
   switch (imageAspectRatio) {
@@ -40,6 +41,7 @@ static NSString *_ImageAspectRatioString(FBSDKShareMessengerGenericTemplateImage
   }
 }
 
+DEPRECATED_MSG_ATTRIBUTE("Sharing to Messenger via the SDK is unsupported. https://developers.facebook.com/docs/messenger-platform/changelog/#20190610. Sharing should be performed by the native share sheet.")
 static NSArray<NSDictionary<NSString *, id> *> *_SerializableGenericTemplateElementsFromElements(NSArray<FBSDKShareMessengerGenericTemplateElement *> *elements)
 {
   NSMutableArray<NSDictionary<NSString *, id> *> *serializableElements = [NSMutableArray array];
@@ -59,7 +61,10 @@ static NSArray<NSDictionary<NSString *, id> *> *_SerializableGenericTemplateElem
   return serializableElements;
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 @implementation FBSDKShareMessengerGenericTemplateContent
+#pragma clang diagnostic pop
 
 #pragma mark - Properties
 

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKShareMessengerGenericTemplateContent.m
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKShareMessengerGenericTemplateContent.m
@@ -30,7 +30,7 @@ static NSString *const kGenericTemplateIsSharableKey = @"isSharable";
 static NSString *const kGenericTemplateImageAspectRatioKey = @"imageAspectRatio";
 static NSString *const kGenericTemplateElementKey = @"element";
 
-DEPRECATED_MSG_ATTRIBUTE("Sharing to Messenger via the SDK is unsupported. https://developers.facebook.com/docs/messenger-platform/changelog/#20190610. Sharing should be performed by the native share sheet.")
+DEPRECATED_FOR_MESSENGER
 static NSString *_ImageAspectRatioString(FBSDKShareMessengerGenericTemplateImageAspectRatio imageAspectRatio)
 {
   switch (imageAspectRatio) {
@@ -41,7 +41,7 @@ static NSString *_ImageAspectRatioString(FBSDKShareMessengerGenericTemplateImage
   }
 }
 
-DEPRECATED_MSG_ATTRIBUTE("Sharing to Messenger via the SDK is unsupported. https://developers.facebook.com/docs/messenger-platform/changelog/#20190610. Sharing should be performed by the native share sheet.")
+DEPRECATED_FOR_MESSENGER
 static NSArray<NSDictionary<NSString *, id> *> *_SerializableGenericTemplateElementsFromElements(NSArray<FBSDKShareMessengerGenericTemplateElement *> *elements)
 {
   NSMutableArray<NSDictionary<NSString *, id> *> *serializableElements = [NSMutableArray array];

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKShareMessengerGenericTemplateElement.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKShareMessengerGenericTemplateElement.h
@@ -29,6 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
  https://developers.facebook.com/docs/messenger-platform/send-messages/template/generic for more details.
  */
 NS_SWIFT_NAME(ShareMessengerGenericTemplateElement)
+DEPRECATED_MSG_ATTRIBUTE("Sharing to Messenger via the SDK is unsupported. https://developers.facebook.com/docs/messenger-platform/changelog/#20190610. Sharing should be performed by the native share sheet.")
 @interface FBSDKShareMessengerGenericTemplateElement : NSObject <FBSDKCopying, NSSecureCoding>
 
 /**

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKShareMessengerGenericTemplateElement.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKShareMessengerGenericTemplateElement.h
@@ -29,7 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
  https://developers.facebook.com/docs/messenger-platform/send-messages/template/generic for more details.
  */
 NS_SWIFT_NAME(ShareMessengerGenericTemplateElement)
-DEPRECATED_MSG_ATTRIBUTE("Sharing to Messenger via the SDK is unsupported. https://developers.facebook.com/docs/messenger-platform/changelog/#20190610. Sharing should be performed by the native share sheet.")
+DEPRECATED_FOR_MESSENGER
 @interface FBSDKShareMessengerGenericTemplateElement : NSObject <FBSDKCopying, NSSecureCoding>
 
 /**

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKShareMessengerGenericTemplateElement.m
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKShareMessengerGenericTemplateElement.m
@@ -24,7 +24,10 @@ static NSString *const kGenericTemplateImageURLKey = @"imageURL";
 static NSString *const kGenericTemplateDefaultActionKey = @"defaultAction";
 static NSString *const kGenericTemplateButtonKey = @"button";
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 @implementation FBSDKShareMessengerGenericTemplateElement
+#pragma clang diagnostic pop
 
 #pragma mark - NSCoding
 

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKShareMessengerMediaTemplateContent.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKShareMessengerMediaTemplateContent.h
@@ -23,7 +23,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-DEPRECATED_MSG_ATTRIBUTE("Sharing to Messenger via the SDK is unsupported. https://developers.facebook.com/docs/messenger-platform/changelog/#20190610. Sharing should be performed by the native share sheet.")
+DEPRECATED_FOR_MESSENGER
 typedef NS_ENUM(NSUInteger, FBSDKShareMessengerMediaTemplateMediaType) {
   FBSDKShareMessengerMediaTemplateMediaTypeImage = 0,
   FBSDKShareMessengerMediaTemplateMediaTypeVideo
@@ -34,7 +34,7 @@ typedef NS_ENUM(NSUInteger, FBSDKShareMessengerMediaTemplateMediaType) {
  https://developers.facebook.com/docs/messenger-platform/send-messages/template/media for details.
  */
 NS_SWIFT_NAME(ShareMessengerMediaTemplateContent)
-DEPRECATED_MSG_ATTRIBUTE("Sharing to Messenger via the SDK is unsupported. https://developers.facebook.com/docs/messenger-platform/changelog/#20190610. Sharing should be performed by the native share sheet.")
+DEPRECATED_FOR_MESSENGER
 @interface FBSDKShareMessengerMediaTemplateContent : NSObject <FBSDKSharingContent>
 
 - (instancetype)init NS_UNAVAILABLE;

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKShareMessengerMediaTemplateContent.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKShareMessengerMediaTemplateContent.h
@@ -23,6 +23,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+DEPRECATED_MSG_ATTRIBUTE("Sharing to Messenger via the SDK is unsupported. https://developers.facebook.com/docs/messenger-platform/changelog/#20190610. Sharing should be performed by the native share sheet.")
 typedef NS_ENUM(NSUInteger, FBSDKShareMessengerMediaTemplateMediaType) {
   FBSDKShareMessengerMediaTemplateMediaTypeImage = 0,
   FBSDKShareMessengerMediaTemplateMediaTypeVideo
@@ -33,6 +34,7 @@ typedef NS_ENUM(NSUInteger, FBSDKShareMessengerMediaTemplateMediaType) {
  https://developers.facebook.com/docs/messenger-platform/send-messages/template/media for details.
  */
 NS_SWIFT_NAME(ShareMessengerMediaTemplateContent)
+DEPRECATED_MSG_ATTRIBUTE("Sharing to Messenger via the SDK is unsupported. https://developers.facebook.com/docs/messenger-platform/changelog/#20190610. Sharing should be performed by the native share sheet.")
 @interface FBSDKShareMessengerMediaTemplateContent : NSObject <FBSDKSharingContent>
 
 - (instancetype)init NS_UNAVAILABLE;

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKShareMessengerMediaTemplateContent.m
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKShareMessengerMediaTemplateContent.m
@@ -55,6 +55,7 @@ static NSString *_MediaTemplateURLSerializationKey(NSURL *mediaURL)
   }
 }
 
+DEPRECATED_MSG_ATTRIBUTE("Sharing to Messenger via the SDK is unsupported. https://developers.facebook.com/docs/messenger-platform/changelog/#20190610. Sharing should be performed by the native share sheet.")
 static NSString *_MediaTypeString(FBSDKShareMessengerMediaTemplateMediaType mediaType)
 {
   switch (mediaType) {
@@ -65,6 +66,7 @@ static NSString *_MediaTypeString(FBSDKShareMessengerMediaTemplateMediaType medi
   }
 }
 
+DEPRECATED_MSG_ATTRIBUTE("Sharing to Messenger via the SDK is unsupported. https://developers.facebook.com/docs/messenger-platform/changelog/#20190610. Sharing should be performed by the native share sheet.")
 static NSArray<NSDictionary<NSString *, id> *> *_SerializableMediaTemplateContentFromContent(FBSDKShareMessengerMediaTemplateContent *mediaTemplateContent)
 {
   NSMutableArray<NSDictionary<NSString *, id> *> *serializableMediaTemplateContent = [NSMutableArray array];
@@ -79,7 +81,10 @@ static NSArray<NSDictionary<NSString *, id> *> *_SerializableMediaTemplateConten
   return serializableMediaTemplateContent;
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 @implementation FBSDKShareMessengerMediaTemplateContent
+#pragma clang diagnostic pop
 
 #pragma mark - Properties
 

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKShareMessengerMediaTemplateContent.m
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKShareMessengerMediaTemplateContent.m
@@ -55,7 +55,7 @@ static NSString *_MediaTemplateURLSerializationKey(NSURL *mediaURL)
   }
 }
 
-DEPRECATED_MSG_ATTRIBUTE("Sharing to Messenger via the SDK is unsupported. https://developers.facebook.com/docs/messenger-platform/changelog/#20190610. Sharing should be performed by the native share sheet.")
+DEPRECATED_FOR_MESSENGER
 static NSString *_MediaTypeString(FBSDKShareMessengerMediaTemplateMediaType mediaType)
 {
   switch (mediaType) {
@@ -66,7 +66,7 @@ static NSString *_MediaTypeString(FBSDKShareMessengerMediaTemplateMediaType medi
   }
 }
 
-DEPRECATED_MSG_ATTRIBUTE("Sharing to Messenger via the SDK is unsupported. https://developers.facebook.com/docs/messenger-platform/changelog/#20190610. Sharing should be performed by the native share sheet.")
+DEPRECATED_FOR_MESSENGER
 static NSArray<NSDictionary<NSString *, id> *> *_SerializableMediaTemplateContentFromContent(FBSDKShareMessengerMediaTemplateContent *mediaTemplateContent)
 {
   NSMutableArray<NSDictionary<NSString *, id> *> *serializableMediaTemplateContent = [NSMutableArray array];

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKShareMessengerOpenGraphMusicTemplateContent.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKShareMessengerOpenGraphMusicTemplateContent.h
@@ -28,7 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
  See https://developers.facebook.com/docs/messenger-platform/send-messages/template/open-graph
  for details. Passing <FBSDKSharingContent> property pageID is required for this type of share.
  */
-DEPRECATED_MSG_ATTRIBUTE("Sharing to Messenger via the SDK is unsupported. https://developers.facebook.com/docs/messenger-platform/changelog/#20190610. Sharing should be performed by the native share sheet.")
+DEPRECATED_FOR_MESSENGER
 NS_SWIFT_NAME(ShareMessengerOpenGraphMusicTemplateContent)
 @interface FBSDKShareMessengerOpenGraphMusicTemplateContent : NSObject <FBSDKSharingContent>
 

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKShareMessengerOpenGraphMusicTemplateContent.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKShareMessengerOpenGraphMusicTemplateContent.h
@@ -28,6 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
  See https://developers.facebook.com/docs/messenger-platform/send-messages/template/open-graph
  for details. Passing <FBSDKSharingContent> property pageID is required for this type of share.
  */
+DEPRECATED_MSG_ATTRIBUTE("Sharing to Messenger via the SDK is unsupported. https://developers.facebook.com/docs/messenger-platform/changelog/#20190610. Sharing should be performed by the native share sheet.")
 NS_SWIFT_NAME(ShareMessengerOpenGraphMusicTemplateContent)
 @interface FBSDKShareMessengerOpenGraphMusicTemplateContent : NSObject <FBSDKSharingContent>
 

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKShareMessengerOpenGraphMusicTemplateContent.m
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKShareMessengerOpenGraphMusicTemplateContent.m
@@ -27,6 +27,7 @@ static NSString *const kMusicTemplateURLKey = @"url";
 static NSString *const kMusicTemplateButtonKey = @"button";
 static NSString *const kMusicTemplateUUIDKey = @"uuid";
 
+DEPRECATED_MSG_ATTRIBUTE("Sharing to Messenger via the SDK is unsupported. https://developers.facebook.com/docs/messenger-platform/changelog/#20190610. Sharing should be performed by the native share sheet.")
 static NSArray<NSDictionary<NSString *, id> *> *_SerializableOpenGraphMusicTemplateContentFromContent(FBSDKShareMessengerOpenGraphMusicTemplateContent *openGraphMusicTemplateContent)
 {
   NSMutableArray<NSDictionary<NSString *, id> *> *serializableOpenGraphMusicTemplateContent = [NSMutableArray array];
@@ -39,7 +40,11 @@ static NSArray<NSDictionary<NSString *, id> *> *_SerializableOpenGraphMusicTempl
   return serializableOpenGraphMusicTemplateContent;
 }
 
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 @implementation FBSDKShareMessengerOpenGraphMusicTemplateContent
+#pragma clang diagnostic pop
 
 #pragma mark - Properties
 

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKShareMessengerOpenGraphMusicTemplateContent.m
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKShareMessengerOpenGraphMusicTemplateContent.m
@@ -27,7 +27,7 @@ static NSString *const kMusicTemplateURLKey = @"url";
 static NSString *const kMusicTemplateButtonKey = @"button";
 static NSString *const kMusicTemplateUUIDKey = @"uuid";
 
-DEPRECATED_MSG_ATTRIBUTE("Sharing to Messenger via the SDK is unsupported. https://developers.facebook.com/docs/messenger-platform/changelog/#20190610. Sharing should be performed by the native share sheet.")
+DEPRECATED_FOR_MESSENGER
 static NSArray<NSDictionary<NSString *, id> *> *_SerializableOpenGraphMusicTemplateContentFromContent(FBSDKShareMessengerOpenGraphMusicTemplateContent *openGraphMusicTemplateContent)
 {
   NSMutableArray<NSDictionary<NSString *, id> *> *serializableOpenGraphMusicTemplateContent = [NSMutableArray array];

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKShareMessengerURLActionButton.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKShareMessengerURLActionButton.h
@@ -31,6 +31,7 @@ typedef NS_ENUM(NSUInteger, FBSDKShareMessengerURLActionButtonWebviewHeightRatio
 /**
  A model for a Messenger share URL action button.
  */
+DEPRECATED_MSG_ATTRIBUTE("Sharing to Messenger via the SDK is unsupported. https://developers.facebook.com/docs/messenger-platform/changelog/#20190610. Sharing should be performed by the native share sheet.")
 NS_SWIFT_NAME(ShareMessengerURLActionButton)
 @interface FBSDKShareMessengerURLActionButton : NSObject <FBSDKShareMessengerActionButton>
 

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKShareMessengerURLActionButton.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKShareMessengerURLActionButton.h
@@ -31,7 +31,7 @@ typedef NS_ENUM(NSUInteger, FBSDKShareMessengerURLActionButtonWebviewHeightRatio
 /**
  A model for a Messenger share URL action button.
  */
-DEPRECATED_MSG_ATTRIBUTE("Sharing to Messenger via the SDK is unsupported. https://developers.facebook.com/docs/messenger-platform/changelog/#20190610. Sharing should be performed by the native share sheet.")
+DEPRECATED_FOR_MESSENGER
 NS_SWIFT_NAME(ShareMessengerURLActionButton)
 @interface FBSDKShareMessengerURLActionButton : NSObject <FBSDKShareMessengerActionButton>
 

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKShareMessengerURLActionButton.m
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKShareMessengerURLActionButton.m
@@ -28,7 +28,10 @@ static NSString *const kURLActionButtonMessengerExtensionsKey = @"messengerExten
 static NSString *const kURLActionButtonFallbackURLKey = @"fallbackURL";
 static NSString *const kURLActionButtonShouldHideWebviewShareButtonKey = @"shouldHideWebviewShareButton";
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 @implementation FBSDKShareMessengerURLActionButton
+#pragma clang diagnostic pop
 
 #pragma mark - Properties
 

--- a/FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareMessengerContentUtility.h
+++ b/FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareMessengerContentUtility.h
@@ -21,20 +21,31 @@
 @class FBSDKShareMessengerURLActionButton;
 @protocol FBSDKShareMessengerActionButton;
 
+DEPRECATED_MSG_ATTRIBUTE("Sharing to Messenger via the SDK is unsupported. https://developers.facebook.com/docs/messenger-platform/changelog/#20190610. Sharing should be performed by the native share sheet.")
 FOUNDATION_EXPORT NSString *const kFBSDKShareMessengerTemplateTypeKey;
+DEPRECATED_MSG_ATTRIBUTE("Sharing to Messenger via the SDK is unsupported. https://developers.facebook.com/docs/messenger-platform/changelog/#20190610. Sharing should be performed by the native share sheet.")
 FOUNDATION_EXPORT NSString *const kFBSDKShareMessengerTemplateKey;
+DEPRECATED_MSG_ATTRIBUTE("Sharing to Messenger via the SDK is unsupported. https://developers.facebook.com/docs/messenger-platform/changelog/#20190610. Sharing should be performed by the native share sheet.")
 FOUNDATION_EXPORT NSString *const kFBSDKShareMessengerPayloadKey;
+DEPRECATED_MSG_ATTRIBUTE("Sharing to Messenger via the SDK is unsupported. https://developers.facebook.com/docs/messenger-platform/changelog/#20190610. Sharing should be performed by the native share sheet.")
 FOUNDATION_EXPORT NSString *const kFBSDKShareMessengerTypeKey;
+DEPRECATED_MSG_ATTRIBUTE("Sharing to Messenger via the SDK is unsupported. https://developers.facebook.com/docs/messenger-platform/changelog/#20190610. Sharing should be performed by the native share sheet.")
 FOUNDATION_EXPORT NSString *const kFBSDKShareMessengerAttachmentKey;
+DEPRECATED_MSG_ATTRIBUTE("Sharing to Messenger via the SDK is unsupported. https://developers.facebook.com/docs/messenger-platform/changelog/#20190610. Sharing should be performed by the native share sheet.")
 FOUNDATION_EXPORT NSString *const kFBSDKShareMessengerElementsKey;
+DEPRECATED_MSG_ATTRIBUTE("Sharing to Messenger via the SDK is unsupported. https://developers.facebook.com/docs/messenger-platform/changelog/#20190610. Sharing should be performed by the native share sheet.")
 FOUNDATION_EXPORT NSString *const kFBSDKShareMessengerButtonsKey;
 
+DEPRECATED_MSG_ATTRIBUTE("Sharing to Messenger via the SDK is unsupported. https://developers.facebook.com/docs/messenger-platform/changelog/#20190610. Sharing should be performed by the native share sheet.")
 void AddToContentPreviewDictionaryForButton(NSMutableDictionary<NSString *, id> *dictionary,
                                             id<FBSDKShareMessengerActionButton> button);
 
 NSDictionary<NSString *, id> *SerializableButtonFromURLButton(FBSDKShareMessengerURLActionButton *button, BOOL isDefaultAction);
+
+DEPRECATED_MSG_ATTRIBUTE("Sharing to Messenger via the SDK is unsupported. https://developers.facebook.com/docs/messenger-platform/changelog/#20190610. Sharing should be performed by the native share sheet.")
 NSArray<NSDictionary<NSString *, id> *> *SerializableButtonsFromButton(id<FBSDKShareMessengerActionButton> button);
 
+DEPRECATED_MSG_ATTRIBUTE("Sharing to Messenger via the SDK is unsupported. https://developers.facebook.com/docs/messenger-platform/changelog/#20190610. Sharing should be performed by the native share sheet.")
 NS_SWIFT_NAME(ShareMessengerContentUtility)
 @interface FBSDKShareMessengerContentUtility : NSObject
 

--- a/FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareMessengerContentUtility.h
+++ b/FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareMessengerContentUtility.h
@@ -17,35 +17,36 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #import <Foundation/Foundation.h>
+#import <FBSDKShareKit/FBSDKShareConstants.h>
 
 @class FBSDKShareMessengerURLActionButton;
 @protocol FBSDKShareMessengerActionButton;
 
-DEPRECATED_MSG_ATTRIBUTE("Sharing to Messenger via the SDK is unsupported. https://developers.facebook.com/docs/messenger-platform/changelog/#20190610. Sharing should be performed by the native share sheet.")
+DEPRECATED_FOR_MESSENGER
 FOUNDATION_EXPORT NSString *const kFBSDKShareMessengerTemplateTypeKey;
-DEPRECATED_MSG_ATTRIBUTE("Sharing to Messenger via the SDK is unsupported. https://developers.facebook.com/docs/messenger-platform/changelog/#20190610. Sharing should be performed by the native share sheet.")
+DEPRECATED_FOR_MESSENGER
 FOUNDATION_EXPORT NSString *const kFBSDKShareMessengerTemplateKey;
-DEPRECATED_MSG_ATTRIBUTE("Sharing to Messenger via the SDK is unsupported. https://developers.facebook.com/docs/messenger-platform/changelog/#20190610. Sharing should be performed by the native share sheet.")
+DEPRECATED_FOR_MESSENGER
 FOUNDATION_EXPORT NSString *const kFBSDKShareMessengerPayloadKey;
-DEPRECATED_MSG_ATTRIBUTE("Sharing to Messenger via the SDK is unsupported. https://developers.facebook.com/docs/messenger-platform/changelog/#20190610. Sharing should be performed by the native share sheet.")
+DEPRECATED_FOR_MESSENGER
 FOUNDATION_EXPORT NSString *const kFBSDKShareMessengerTypeKey;
-DEPRECATED_MSG_ATTRIBUTE("Sharing to Messenger via the SDK is unsupported. https://developers.facebook.com/docs/messenger-platform/changelog/#20190610. Sharing should be performed by the native share sheet.")
+DEPRECATED_FOR_MESSENGER
 FOUNDATION_EXPORT NSString *const kFBSDKShareMessengerAttachmentKey;
-DEPRECATED_MSG_ATTRIBUTE("Sharing to Messenger via the SDK is unsupported. https://developers.facebook.com/docs/messenger-platform/changelog/#20190610. Sharing should be performed by the native share sheet.")
+DEPRECATED_FOR_MESSENGER
 FOUNDATION_EXPORT NSString *const kFBSDKShareMessengerElementsKey;
-DEPRECATED_MSG_ATTRIBUTE("Sharing to Messenger via the SDK is unsupported. https://developers.facebook.com/docs/messenger-platform/changelog/#20190610. Sharing should be performed by the native share sheet.")
+DEPRECATED_FOR_MESSENGER
 FOUNDATION_EXPORT NSString *const kFBSDKShareMessengerButtonsKey;
 
-DEPRECATED_MSG_ATTRIBUTE("Sharing to Messenger via the SDK is unsupported. https://developers.facebook.com/docs/messenger-platform/changelog/#20190610. Sharing should be performed by the native share sheet.")
+DEPRECATED_FOR_MESSENGER
 void AddToContentPreviewDictionaryForButton(NSMutableDictionary<NSString *, id> *dictionary,
                                             id<FBSDKShareMessengerActionButton> button);
 
 NSDictionary<NSString *, id> *SerializableButtonFromURLButton(FBSDKShareMessengerURLActionButton *button, BOOL isDefaultAction);
 
-DEPRECATED_MSG_ATTRIBUTE("Sharing to Messenger via the SDK is unsupported. https://developers.facebook.com/docs/messenger-platform/changelog/#20190610. Sharing should be performed by the native share sheet.")
+DEPRECATED_FOR_MESSENGER
 NSArray<NSDictionary<NSString *, id> *> *SerializableButtonsFromButton(id<FBSDKShareMessengerActionButton> button);
 
-DEPRECATED_MSG_ATTRIBUTE("Sharing to Messenger via the SDK is unsupported. https://developers.facebook.com/docs/messenger-platform/changelog/#20190610. Sharing should be performed by the native share sheet.")
+DEPRECATED_FOR_MESSENGER
 NS_SWIFT_NAME(ShareMessengerContentUtility)
 @interface FBSDKShareMessengerContentUtility : NSObject
 

--- a/FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareMessengerContentUtility.m
+++ b/FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareMessengerContentUtility.m
@@ -35,7 +35,7 @@ NSString *const kFBSDKShareMessengerAttachmentKey = @"attachment";
 NSString *const kFBSDKShareMessengerElementsKey = @"elements";
 NSString *const kFBSDKShareMessengerButtonsKey = @"buttons";
 
-DEPRECATED_MSG_ATTRIBUTE("Sharing to Messenger via the SDK is unsupported. https://developers.facebook.com/docs/messenger-platform/changelog/#20190610. Sharing should be performed by the native share sheet.")
+DEPRECATED_FOR_MESSENGER
 static void _AddToContentPreviewDictionaryForURLButton(NSMutableDictionary<NSString *, id> *dictionary,
                                                        FBSDKShareMessengerURLActionButton *urlButton)
 {

--- a/FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareMessengerContentUtility.m
+++ b/FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareMessengerContentUtility.m
@@ -35,6 +35,7 @@ NSString *const kFBSDKShareMessengerAttachmentKey = @"attachment";
 NSString *const kFBSDKShareMessengerElementsKey = @"elements";
 NSString *const kFBSDKShareMessengerButtonsKey = @"buttons";
 
+DEPRECATED_MSG_ATTRIBUTE("Sharing to Messenger via the SDK is unsupported. https://developers.facebook.com/docs/messenger-platform/changelog/#20190610. Sharing should be performed by the native share sheet.")
 static void _AddToContentPreviewDictionaryForURLButton(NSMutableDictionary<NSString *, id> *dictionary,
                                                        FBSDKShareMessengerURLActionButton *urlButton)
 {
@@ -59,7 +60,10 @@ void AddToContentPreviewDictionaryForButton(NSMutableDictionary<NSString *, id> 
   }
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 @implementation FBSDKShareMessengerContentUtility
+#pragma clang diagnostic pop
 
 static NSString *_WebviewHeightRatioString(FBSDKShareMessengerURLActionButtonWebviewHeightRatio heightRatio) {
   switch (heightRatio) {


### PR DESCRIPTION
Thanks for proposing a pull request!

To help us review the request, please complete the following:

- [x] sign [contributor license agreement](https://developers.facebook.com/opensource/cla)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [x] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

Deprecates messenger sharing. See: https://developers.facebook.com/docs/sharing/messenger for more details on why the deprecation is occurring and how you can update your application to account for this change.

## Test Plan

N/A
