### PR TITLE
Carthage for swift targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,6 +99,7 @@ jobs:
         api_key: $GITHUB_ACCESS_TOKEN
         file: build/Release/*
         file_glob: true
+        overwrite: true
         name: Facebook SDK $TRAVIS_TAG
         body: Consult Changelog $TRAVIS_TAG
         on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -90,6 +90,21 @@ jobs:
           all_branches: true
           tags: true
     - stage: release
+      name: GitHub Release Combine Output for Carthage
+      osx_image: xcode10.3
+      script: sh scripts/run.sh release github combine
+      deploy:
+        provider: releases
+        skip_cleanup: true
+        api_key: $GITHUB_ACCESS_TOKEN
+        file: build/Release/*
+        file_glob: true
+        name: Facebook SDK $TRAVIS_TAG
+        body: Consult Changelog $TRAVIS_TAG
+        on:
+          all_branches: true
+          tags: true
+    - stage: release
       name: Publish Cocoapods
       osx_image: xcode10.3
       script: sh scripts/run.sh release cocoapods --allow-warnings

--- a/FBSDKCoreKit/FBSDKCoreKit.xcodeproj/project.pbxproj
+++ b/FBSDKCoreKit/FBSDKCoreKit.xcodeproj/project.pbxproj
@@ -803,6 +803,225 @@
 		C5D25D3921795B790037B13D /* FBSDKCodelessIndexer.m in Sources */ = {isa = PBXBuildFile; fileRef = C5D25D3521795B790037B13D /* FBSDKCodelessIndexer.m */; };
 		C5DFB84322CBC1EB0086E16C /* FBSDKTypeUtility.h in Headers */ = {isa = PBXBuildFile; fileRef = C5C4B3E32276B88600CA3706 /* FBSDKTypeUtility.h */; };
 		C5F6EC861FA24FAF009EB258 /* FBSDKPaymentObserverTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C5F6EC851FA24FAF009EB258 /* FBSDKPaymentObserverTests.m */; };
+		F483F333233AC13000703DE3 /* FBSDKGraphRequestPiggybackManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 9DA81B281AA65FA200B9FE0B /* FBSDKGraphRequestPiggybackManager.m */; };
+		F483F334233AC13000703DE3 /* FBSDKAppEventsStateManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D0BC15E1A8D428700BE8BA4 /* FBSDKAppEventsStateManager.m */; };
+		F483F335233AC13000703DE3 /* FBSDKServerConfigurationManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 89830F2A1A7805D100226ABB /* FBSDKServerConfigurationManager.m */; };
+		F483F336233AC13000703DE3 /* FBSDKGraphRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 9DC658941A6EE5C500B85AAF /* FBSDKGraphRequest.m */; };
+		F483F337233AC13000703DE3 /* FBSDKContainerViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D195CC71B9FE2E000BD6BEC /* FBSDKContainerViewController.m */; };
+		F483F338233AC13000703DE3 /* FBSDKHybridAppEventsScriptMessageHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = C4FC99D8202CD5590038C5ED /* FBSDKHybridAppEventsScriptMessageHandler.m */; };
+		F483F339233AC13000703DE3 /* FBSDKAccessTokenCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D32A8441A699459000A936D /* FBSDKAccessTokenCache.m */; };
+		F483F33A233AC13000703DE3 /* FBSDKCrypto.m in Sources */ = {isa = PBXBuildFile; fileRef = 894C0B081A702194009137EF /* FBSDKCrypto.m */; };
+		F483F33B233AC13000703DE3 /* FBSDKAppEventsState.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D0BC1651A8E892C00BE8BA4 /* FBSDKAppEventsState.m */; };
+		F483F33C233AC13000703DE3 /* FBSDKCloseIcon.m in Sources */ = {isa = PBXBuildFile; fileRef = 89D652831A855A6000BB651C /* FBSDKCloseIcon.m */; };
+		F483F33D233AC13000703DE3 /* Dictionary+KeyValueMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = F487DBCE231EC20E008416A9 /* Dictionary+KeyValueMap.swift */; };
+		F483F33E233AC13000703DE3 /* FBSDKWebViewAppLinkResolver.m in Sources */ = {isa = PBXBuildFile; fileRef = 52963A6D215992F100C7B252 /* FBSDKWebViewAppLinkResolver.m */; };
+		F483F33F233AC13000703DE3 /* FBSDKRestrictiveDataFilterManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D411318229F27DD002FF65A /* FBSDKRestrictiveDataFilterManager.m */; };
+		F483F340233AC13000703DE3 /* FBSDKBase64.m in Sources */ = {isa = PBXBuildFile; fileRef = 894C0B101A7021F8009137EF /* FBSDKBase64.m */; };
+		F483F341233AC13000703DE3 /* FBSDKBridgeAPIProtocolWebV2.m in Sources */ = {isa = PBXBuildFile; fileRef = 89F2038A1AA960FA0053499E /* FBSDKBridgeAPIProtocolWebV2.m */; };
+		F483F342233AC13000703DE3 /* FBSDKGraphRequestBody.m in Sources */ = {isa = PBXBuildFile; fileRef = 9DC658A11A6EE7E200B85AAF /* FBSDKGraphRequestBody.m */; };
+		F483F343233AC13000703DE3 /* FBSDKUtility.m in Sources */ = {isa = PBXBuildFile; fileRef = 89C8B1981A8D7A15009B07F5 /* FBSDKUtility.m */; };
+		F483F344233AC13000703DE3 /* FBSDKTestUsersManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D7E7E601ADF038800F53E38 /* FBSDKTestUsersManager.m */; };
+		F483F345233AC13000703DE3 /* FBSDKMeasurementEventListener.m in Sources */ = {isa = PBXBuildFile; fileRef = 7EB63D9D1A9BE730003A7AED /* FBSDKMeasurementEventListener.m */; };
+		F483F346233AC13000703DE3 /* FBSDKProfilePictureView.m in Sources */ = {isa = PBXBuildFile; fileRef = 899C3CF71A8BF73A00EA8658 /* FBSDKProfilePictureView.m */; };
+		F483F347233AC13000703DE3 /* FBSDKTriStateBOOL.m in Sources */ = {isa = PBXBuildFile; fileRef = 89D05A941AA0E89B00609300 /* FBSDKTriStateBOOL.m */; };
+		F483F348233AC13000703DE3 /* FBSDKLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D6999FD1A76E166003AE384 /* FBSDKLogger.m */; };
+		F483F349233AC13000703DE3 /* FBSDKApplicationDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D34A11E1A5F038300C37317 /* FBSDKApplicationDelegate.m */; };
+		F483F34A233AC13000703DE3 /* FBSDKBridgeAPI.m in Sources */ = {isa = PBXBuildFile; fileRef = C5188E322231C4B500F4D8BC /* FBSDKBridgeAPI.m */; };
+		F483F34B233AC13000703DE3 /* Permission.swift in Sources */ = {isa = PBXBuildFile; fileRef = F487DBCB231EC1A0008416A9 /* Permission.swift */; };
+		F483F34C233AC13000703DE3 /* FBSDKDynamicFrameworkLoader.m in Sources */ = {isa = PBXBuildFile; fileRef = 81C969311C114723002FC037 /* FBSDKDynamicFrameworkLoader.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		F483F34D233AC13000703DE3 /* FBSDKAppLinkNavigation.m in Sources */ = {isa = PBXBuildFile; fileRef = 52963A68215992F000C7B252 /* FBSDKAppLinkNavigation.m */; };
+		F483F34E233AC13000703DE3 /* FBSDKGraphRequestDataAttachment.m in Sources */ = {isa = PBXBuildFile; fileRef = 896DE2331A9E509300195731 /* FBSDKGraphRequestDataAttachment.m */; };
+		F483F34F233AC13000703DE3 /* FBSDKDialogConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 89830F321A78060A00226ABB /* FBSDKDialogConfiguration.m */; };
+		F483F350233AC13000703DE3 /* FBSDKSwizzler.m in Sources */ = {isa = PBXBuildFile; fileRef = C5696FA2209CCEB4009C931F /* FBSDKSwizzler.m */; };
+		F483F351233AC13000703DE3 /* FBSDKAccessToken.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D3029091A65C4420086B9ED /* FBSDKAccessToken.m */; };
+		F483F352233AC13000703DE3 /* FBSDKURL.m in Sources */ = {isa = PBXBuildFile; fileRef = 52963A6B215992F100C7B252 /* FBSDKURL.m */; };
+		F483F353233AC13000703DE3 /* FBSDKInternalUtility.m in Sources */ = {isa = PBXBuildFile; fileRef = 893F448A1A642F11001DB0B6 /* FBSDKInternalUtility.m */; };
+		F483F354233AC13000703DE3 /* FBSDKMonotonicTime.m in Sources */ = {isa = PBXBuildFile; fileRef = ADEA17721B7ECA1A0070EDC0 /* FBSDKMonotonicTime.m */; };
+		F483F355233AC13000703DE3 /* FBSDKAppLinkUtility.m in Sources */ = {isa = PBXBuildFile; fileRef = 7E3091791AA907E0004E91D5 /* FBSDKAppLinkUtility.m */; };
+		F483F356233AC13000703DE3 /* FBSDKViewImpressionTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = 89688B611AA64C5E00A98519 /* FBSDKViewImpressionTracker.m */; };
+		F483F357233AC13000703DE3 /* FBSDKLibAnalyzer.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D9A704223261D6900BF9783 /* FBSDKLibAnalyzer.m */; };
+		F483F358233AC13000703DE3 /* FBSDKImageDownloader.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D28F1921DB14DBB0057D709 /* FBSDKImageDownloader.m */; };
+		F483F359233AC13000703DE3 /* FBSDKBridgeAPIRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 894C0AD01A6F15F7009137EF /* FBSDKBridgeAPIRequest.m */; };
+		F483F35A233AC13000703DE3 /* FBSDKViewHierarchy.m in Sources */ = {isa = PBXBuildFile; fileRef = C5696F21209BBC35009C931F /* FBSDKViewHierarchy.m */; };
+		F483F35B233AC13000703DE3 /* FBSDKCodelessParameterComponent.m in Sources */ = {isa = PBXBuildFile; fileRef = C5696F27209BBC35009C931F /* FBSDKCodelessParameterComponent.m */; };
+		F483F35C233AC13000703DE3 /* FBSDKBasicUtility.m in Sources */ = {isa = PBXBuildFile; fileRef = 5DEF22CE226A3E06004056C1 /* FBSDKBasicUtility.m */; };
+		F483F35D233AC13000703DE3 /* FBSDKAppEventsDeviceInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 5F7064081AF7342600E42ED7 /* FBSDKAppEventsDeviceInfo.m */; };
+		F483F35E233AC13000703DE3 /* FBSDKError.m in Sources */ = {isa = PBXBuildFile; fileRef = 894C0B601A7150AC009137EF /* FBSDKError.m */; };
+		F483F35F233AC13000703DE3 /* FBSDKAudioResourceLoader.m in Sources */ = {isa = PBXBuildFile; fileRef = 89D05AA81AA1134000609300 /* FBSDKAudioResourceLoader.m */; };
+		F483F360233AC13000703DE3 /* FBSDKLogo.m in Sources */ = {isa = PBXBuildFile; fileRef = 893F44941A6444DF001DB0B6 /* FBSDKLogo.m */; };
+		F483F361233AC13000703DE3 /* FBSDKPaymentObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D0BC14B1A8D236200BE8BA4 /* FBSDKPaymentObserver.m */; };
+		F483F362233AC13000703DE3 /* FBSDKBridgeAPIResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = 894C0ADE1A6F1D1B009137EF /* FBSDKBridgeAPIResponse.m */; };
+		F483F363233AC13000703DE3 /* FBSDKCrashHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D9A703F23261D6900BF9783 /* FBSDKCrashHandler.m */; };
+		F483F364233AC13000703DE3 /* FBSDKErrorRecoveryConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D3AF45F1A9EC24800EEF724 /* FBSDKErrorRecoveryConfiguration.m */; };
+		F483F365233AC13000703DE3 /* FBProfilePictureView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F487DBD2231EC20F008416A9 /* FBProfilePictureView.swift */; };
+		F483F366233AC13000703DE3 /* FBSDKGraphErrorRecoveryProcessor.m in Sources */ = {isa = PBXBuildFile; fileRef = 9DD50A3B1A9BBA1B0088AAAA /* FBSDKGraphErrorRecoveryProcessor.m */; };
+		F483F367233AC13000703DE3 /* FBSDKAppLinkReturnToRefererController.m in Sources */ = {isa = PBXBuildFile; fileRef = 52963A71215992F200C7B252 /* FBSDKAppLinkReturnToRefererController.m */; };
+		F483F368233AC13000703DE3 /* FBSDKTimeSpentData.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D0BC14D1A8D236200BE8BA4 /* FBSDKTimeSpentData.m */; };
+		F483F369233AC13000703DE3 /* FBSDKBridgeAPIProtocolWebV1.m in Sources */ = {isa = PBXBuildFile; fileRef = 89D4AE9E1A803F1E00DB8C72 /* FBSDKBridgeAPIProtocolWebV1.m */; };
+		F483F36A233AC13000703DE3 /* FBSDKMath.m in Sources */ = {isa = PBXBuildFile; fileRef = 893F44AB1A644744001DB0B6 /* FBSDKMath.m */; };
+		F483F36B233AC13000703DE3 /* FBSDKWebDialog.m in Sources */ = {isa = PBXBuildFile; fileRef = 89FB8C401A8425C4003CAE60 /* FBSDKWebDialog.m */; };
+		F483F36C233AC13000703DE3 /* FBSDKEventBinding.m in Sources */ = {isa = PBXBuildFile; fileRef = C5696F24209BBC35009C931F /* FBSDKEventBinding.m */; };
+		F483F36D233AC13000703DE3 /* FBSDKAccessTokenExpirer.m in Sources */ = {isa = PBXBuildFile; fileRef = 033429B120894D4700C94913 /* FBSDKAccessTokenExpirer.m */; };
+		F483F36E233AC13000703DE3 /* FBSDKTypeUtility.m in Sources */ = {isa = PBXBuildFile; fileRef = C5C4B3E52276B88600CA3706 /* FBSDKTypeUtility.m */; };
+		F483F36F233AC13000703DE3 /* FBSDKColor.m in Sources */ = {isa = PBXBuildFile; fileRef = 9DBA6A301A80265A00B4DE6A /* FBSDKColor.m */; };
+		F483F370233AC13000703DE3 /* FBSDKAppLinkResolver.m in Sources */ = {isa = PBXBuildFile; fileRef = 7E5557351A8D833100344F86 /* FBSDKAppLinkResolver.m */; };
+		F483F371233AC13000703DE3 /* FBSDKIcon.m in Sources */ = {isa = PBXBuildFile; fileRef = 891687D11AB33CA200F55364 /* FBSDKIcon.m */; };
+		F483F372233AC13000703DE3 /* FBSDKConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 894C0B671A7150CC009137EF /* FBSDKConstants.m */; };
+		F483F373233AC13000703DE3 /* FBSDKAppEventsUtility.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D0BC15A1A8D427800BE8BA4 /* FBSDKAppEventsUtility.m */; };
+		F483F374233AC13000703DE3 /* AccessToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = F487DBD9231EC293008416A9 /* AccessToken.swift */; };
+		F483F375233AC13000703DE3 /* FBSDKInstrumentManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 5DB7B08D2303632E0012E8CB /* FBSDKInstrumentManager.m */; };
+		F483F376233AC13000703DE3 /* FBSDKCodelessPathComponent.m in Sources */ = {isa = PBXBuildFile; fileRef = C5696F1E209BBC35009C931F /* FBSDKCodelessPathComponent.m */; };
+		F483F377233AC13000703DE3 /* FBSDKSettings.m in Sources */ = {isa = PBXBuildFile; fileRef = 9DA8303B1A6999EC00770955 /* FBSDKSettings.m */; };
+		F483F378233AC13000703DE3 /* FBSDKAppLink.m in Sources */ = {isa = PBXBuildFile; fileRef = 52963A6C215992F100C7B252 /* FBSDKAppLink.m */; };
+		F483F379233AC13000703DE3 /* FBSDKAppLinkReturnToRefererView.m in Sources */ = {isa = PBXBuildFile; fileRef = 52963A65215992F000C7B252 /* FBSDKAppLinkReturnToRefererView.m */; };
+		F483F37A233AC13000703DE3 /* FBSDKButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 891687ED1AB38C7C00F55364 /* FBSDKButton.m */; };
+		F483F37B233AC13000703DE3 /* FBSDKCodelessIndexer.m in Sources */ = {isa = PBXBuildFile; fileRef = C5D25D3521795B790037B13D /* FBSDKCodelessIndexer.m */; };
+		F483F37C233AC13000703DE3 /* FBSDKGraphRequestMetadata.m in Sources */ = {isa = PBXBuildFile; fileRef = 9DF2A3FE1A70572B00DFB2FD /* FBSDKGraphRequestMetadata.m */; };
+		F483F37D233AC13000703DE3 /* FBSDKErrorRecoveryAttempter.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D3AF4881A9EFA0300EEF724 /* FBSDKErrorRecoveryAttempter.m */; };
+		F483F37E233AC13000703DE3 /* FBSDKAppLinkTarget.m in Sources */ = {isa = PBXBuildFile; fileRef = 52963A67215992F000C7B252 /* FBSDKAppLinkTarget.m */; };
+		F483F37F233AC13000703DE3 /* FBSDKProfile.m in Sources */ = {isa = PBXBuildFile; fileRef = 9DA81AF51AA4EF3300B9FE0B /* FBSDKProfile.m */; };
+		F483F380233AC13000703DE3 /* FBSDKEventBindingManager.m in Sources */ = {isa = PBXBuildFile; fileRef = C5696F23209BBC35009C931F /* FBSDKEventBindingManager.m */; };
+		F483F381233AC13000703DE3 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		F483F382233AC13000703DE3 /* FBSDKKeychainStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D32A83D1A69941A000A936D /* FBSDKKeychainStore.m */; };
+		F483F383233AC13000703DE3 /* FBSDKGraphRequestConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = 9DC6589D1A6EE7D800B85AAF /* FBSDKGraphRequestConnection.m */; };
+		F483F384233AC13000703DE3 /* FBSDKAppEvents.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D0BC1561A8D23E200BE8BA4 /* FBSDKAppEvents.m */; };
+		F483F385233AC13000703DE3 /* FBSDKGateKeeperManager.m in Sources */ = {isa = PBXBuildFile; fileRef = F9FD9A7C21659F320068DEAF /* FBSDKGateKeeperManager.m */; };
+		F483F386233AC13000703DE3 /* FBSDKUserDataStore.m in Sources */ = {isa = PBXBuildFile; fileRef = F9169B832155A03C00FA1789 /* FBSDKUserDataStore.m */; };
+		F483F387233AC13000703DE3 /* FBSDKURLSession.m in Sources */ = {isa = PBXBuildFile; fileRef = F9098FC222BC332C00857C2D /* FBSDKURLSession.m */; };
+		F483F388233AC13000703DE3 /* _FBSDKTemporaryErrorRecoveryAttempter.m in Sources */ = {isa = PBXBuildFile; fileRef = 9DF18BB81A9F1A05000F6748 /* _FBSDKTemporaryErrorRecoveryAttempter.m */; };
+		F483F389233AC13000703DE3 /* FBSDKMeasurementEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = 52963AAB2159A16E00C7B252 /* FBSDKMeasurementEvent.m */; };
+		F483F38A233AC13000703DE3 /* FBSDKBridgeAPIProtocolNativeV1.m in Sources */ = {isa = PBXBuildFile; fileRef = 894C0AF51A6F2278009137EF /* FBSDKBridgeAPIProtocolNativeV1.m */; };
+		F483F38B233AC13000703DE3 /* FBSDKCrashObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D4360DF23219F8E00254DF7 /* FBSDKCrashObserver.m */; };
+		F483F38C233AC13000703DE3 /* FBSDKWebDialogView.m in Sources */ = {isa = PBXBuildFile; fileRef = 89FB8C491A842A8A003CAE60 /* FBSDKWebDialogView.m */; };
+		F483F38D233AC13000703DE3 /* FBSDKErrorConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D3AF44F1A9EA4BE00EEF724 /* FBSDKErrorConfiguration.m */; };
+		F483F38E233AC13000703DE3 /* FBSDKDeviceRequestsHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 520223F61D83C8D200CE0AB5 /* FBSDKDeviceRequestsHelper.m */; };
+		F483F38F233AC13000703DE3 /* FBSDKKeychainStoreViaBundleID.m in Sources */ = {isa = PBXBuildFile; fileRef = 9DE1F3CC1A89D9CD00B54D98 /* FBSDKKeychainStoreViaBundleID.m */; };
+		F483F390233AC13000703DE3 /* Settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = F487DBCD231EC20E008416A9 /* Settings.swift */; };
+		F483F391233AC13000703DE3 /* FBSDKServerConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 89830F2E1A7805E100226ABB /* FBSDKServerConfiguration.m */; };
+		F483F392233AC13000703DE3 /* FBSDKErrorReport.m in Sources */ = {isa = PBXBuildFile; fileRef = FD8E438022FBF8F1008B6DD3 /* FBSDKErrorReport.m */; };
+		F483F393233AC13000703DE3 /* FBSDKMaleSilhouetteIcon.m in Sources */ = {isa = PBXBuildFile; fileRef = 899C3D011A8C1ED200EA8658 /* FBSDKMaleSilhouetteIcon.m */; };
+		F483F394233AC13000703DE3 /* FBSDKFeatureManager.m in Sources */ = {isa = PBXBuildFile; fileRef = C5C7B74922D84F64004A5A0C /* FBSDKFeatureManager.m */; };
+		F483F395233AC13000703DE3 /* FBSDKURLSessionTask.m in Sources */ = {isa = PBXBuildFile; fileRef = F92F8F7D22BA274300494727 /* FBSDKURLSessionTask.m */; };
+		F483F397233AC13000703DE3 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C4513900202CBF1F0063275D /* WebKit.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		F483F398233AC13000703DE3 /* SafariServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9894BFFA1B73D8B300FBA6DB /* SafariServices.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		F483F39A233AC13000703DE3 /* FBSDKAppLinkUtility.h in Headers */ = {isa = PBXBuildFile; fileRef = 7E30916C1AA907BD004E91D5 /* FBSDKAppLinkUtility.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F39B233AC13000703DE3 /* FBSDKAppLinkResolver.h in Headers */ = {isa = PBXBuildFile; fileRef = 7E5557361A8D833100344F86 /* FBSDKAppLinkResolver.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F39C233AC13000703DE3 /* FBSDKAccessTokenCaching.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D32A83B1A69941A000A936D /* FBSDKAccessTokenCaching.h */; };
+		F483F39D233AC13000703DE3 /* FBSDKBridgeAPIResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 894C0ADD1A6F1D1B009137EF /* FBSDKBridgeAPIResponse.h */; };
+		F483F39E233AC13000703DE3 /* FBSDKCoreKit+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 890414731A647D2E00617215 /* FBSDKCoreKit+Internal.h */; };
+		F483F39F233AC13000703DE3 /* FBSDKMeasurementEventListener.h in Headers */ = {isa = PBXBuildFile; fileRef = 7EB63D9E1A9BE730003A7AED /* FBSDKMeasurementEventListener.h */; };
+		F483F3A0233AC13000703DE3 /* FBSDKAudioResourceLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 89D05AA71AA1134000609300 /* FBSDKAudioResourceLoader.h */; };
+		F483F3A1233AC13000703DE3 /* FBSDKLogo.h in Headers */ = {isa = PBXBuildFile; fileRef = 893F44931A6444DF001DB0B6 /* FBSDKLogo.h */; };
+		F483F3A2233AC13000703DE3 /* FBSDKMeasurementEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 52963AAA2159A16E00C7B252 /* FBSDKMeasurementEvent.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F3A3233AC13000703DE3 /* FBSDKProfilePictureView.h in Headers */ = {isa = PBXBuildFile; fileRef = 899C3CF61A8BF73A00EA8658 /* FBSDKProfilePictureView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F3A4233AC13000703DE3 /* FBSDKButton.h in Headers */ = {isa = PBXBuildFile; fileRef = 891687EC1AB38C7C00F55364 /* FBSDKButton.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F3A5233AC13000703DE3 /* FBSDKAppLinkResolving.h in Headers */ = {isa = PBXBuildFile; fileRef = 52963A69215992F100C7B252 /* FBSDKAppLinkResolving.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F3A6233AC13000703DE3 /* FBSDKBridgeAPIProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 894C0AF21A6F21A1009137EF /* FBSDKBridgeAPIProtocol.h */; };
+		F483F3A7233AC13000703DE3 /* FBSDKEventBinding.h in Headers */ = {isa = PBXBuildFile; fileRef = C5696F31209BBC35009C931F /* FBSDKEventBinding.h */; };
+		F483F3A8233AC13000703DE3 /* FBSDKGraphErrorRecoveryProcessor.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DD50A3A1A9BBA1B0088AAAA /* FBSDKGraphErrorRecoveryProcessor.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F3A9233AC13000703DE3 /* FBSDKBase64.h in Headers */ = {isa = PBXBuildFile; fileRef = 894C0B0F1A7021F8009137EF /* FBSDKBase64.h */; };
+		F483F3AA233AC13000703DE3 /* FBSDKAppEventsUtility.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D0BC1591A8D427800BE8BA4 /* FBSDKAppEventsUtility.h */; };
+		F483F3AB233AC13000703DE3 /* FBSDKAppEvents+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D0BC1531A8D23DB00BE8BA4 /* FBSDKAppEvents+Internal.h */; };
+		F483F3AC233AC13000703DE3 /* FBSDKImageDownloader.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D28F1911DB14DBB0057D709 /* FBSDKImageDownloader.h */; };
+		F483F3AD233AC13000703DE3 /* FBSDKBasicUtility.h in Headers */ = {isa = PBXBuildFile; fileRef = C5C4B3E42276B88600CA3706 /* FBSDKBasicUtility.h */; };
+		F483F3AE233AC13000703DE3 /* FBSDKErrorConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D3AF44E1A9EA4BE00EEF724 /* FBSDKErrorConfiguration.h */; };
+		F483F3AF233AC13000703DE3 /* FBSDKTimeSpentData.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D0BC14C1A8D236200BE8BA4 /* FBSDKTimeSpentData.h */; };
+		F483F3B0233AC13000703DE3 /* FBSDKIcon.h in Headers */ = {isa = PBXBuildFile; fileRef = 891687D01AB33CA200F55364 /* FBSDKIcon.h */; };
+		F483F3B1233AC13000703DE3 /* FBSDKAppLinkReturnToRefererView.h in Headers */ = {isa = PBXBuildFile; fileRef = 52963A73215992F300C7B252 /* FBSDKAppLinkReturnToRefererView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F3B2233AC13000703DE3 /* FBSDKMeasurementEvent_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 52963AA72159A13300C7B252 /* FBSDKMeasurementEvent_Internal.h */; };
+		F483F3B3233AC13000703DE3 /* FBSDKContainerViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D195CC61B9FE2E000BD6BEC /* FBSDKContainerViewController.h */; };
+		F483F3B4233AC13000703DE3 /* FBSDKAppEventsState.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D0BC1641A8E892C00BE8BA4 /* FBSDKAppEventsState.h */; };
+		F483F3B5233AC13000703DE3 /* FBSDKURLSessionTask.h in Headers */ = {isa = PBXBuildFile; fileRef = F92F8F7C22BA274300494727 /* FBSDKURLSessionTask.h */; };
+		F483F3B6233AC13000703DE3 /* FBSDKBridgeAPIProtocolType.h in Headers */ = {isa = PBXBuildFile; fileRef = 894C0AEC1A6F1DAB009137EF /* FBSDKBridgeAPIProtocolType.h */; };
+		F483F3B7233AC13000703DE3 /* FBSDKMaleSilhouetteIcon.h in Headers */ = {isa = PBXBuildFile; fileRef = 899C3D001A8C1ED200EA8658 /* FBSDKMaleSilhouetteIcon.h */; };
+		F483F3B8233AC13000703DE3 /* FBSDKCrashHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D9A704023261D6900BF9783 /* FBSDKCrashHandler.h */; };
+		F483F3B9233AC13000703DE3 /* FBSDKCrashObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D4360DA23219F7900254DF7 /* FBSDKCrashObserver.h */; };
+		F483F3BA233AC13000703DE3 /* FBSDKMutableCopying.h in Headers */ = {isa = PBXBuildFile; fileRef = 890414871A64893100617215 /* FBSDKMutableCopying.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F3BB233AC13000703DE3 /* FBSDKTypeUtility.h in Headers */ = {isa = PBXBuildFile; fileRef = C5C4B3E32276B88600CA3706 /* FBSDKTypeUtility.h */; };
+		F483F3BC233AC13000703DE3 /* FBSDKSwizzler.h in Headers */ = {isa = PBXBuildFile; fileRef = C5696FA1209CCEB3009C931F /* FBSDKSwizzler.h */; };
+		F483F3BD233AC13000703DE3 /* FBSDKErrorRecoveryAttempter.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D3AF4871A9EFA0300EEF724 /* FBSDKErrorRecoveryAttempter.h */; };
+		F483F3BE233AC13000703DE3 /* FBSDKPaymentObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D0BC14A1A8D236200BE8BA4 /* FBSDKPaymentObserver.h */; };
+		F483F3BF233AC13000703DE3 /* FBSDKProfile+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DE6C46D1AAF6E2800EC4C99 /* FBSDKProfile+Internal.h */; };
+		F483F3C0233AC13000703DE3 /* FBSDKBridgeAPIProtocolWebV1.h in Headers */ = {isa = PBXBuildFile; fileRef = 89D4AE9D1A803F1E00DB8C72 /* FBSDKBridgeAPIProtocolWebV1.h */; };
+		F483F3C1233AC13000703DE3 /* FBSDKBridgeAPI.h in Headers */ = {isa = PBXBuildFile; fileRef = C5188E312231C4B500F4D8BC /* FBSDKBridgeAPI.h */; };
+		F483F3C2233AC13000703DE3 /* FBSDKEventBindingManager.h in Headers */ = {isa = PBXBuildFile; fileRef = C5696F2B209BBC35009C931F /* FBSDKEventBindingManager.h */; };
+		F483F3C3233AC13000703DE3 /* FBSDKBridgeAPIRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 894C0ACF1A6F15F7009137EF /* FBSDKBridgeAPIRequest.h */; };
+		F483F3C4233AC13000703DE3 /* FBSDKWebDialogView.h in Headers */ = {isa = PBXBuildFile; fileRef = 89FB8C481A842A8A003CAE60 /* FBSDKWebDialogView.h */; };
+		F483F3C5233AC13000703DE3 /* FBSDKInstrumentManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 5DB7B07B230363190012E8CB /* FBSDKInstrumentManager.h */; };
+		F483F3C6233AC13000703DE3 /* FBSDKServerConfiguration+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 8917C4AB1B7A46C800B0B96B /* FBSDKServerConfiguration+Internal.h */; };
+		F483F3C7233AC13000703DE3 /* FBSDKTriStateBOOL.h in Headers */ = {isa = PBXBuildFile; fileRef = 89D05A931AA0E89B00609300 /* FBSDKTriStateBOOL.h */; };
+		F483F3C8233AC13000703DE3 /* FBSDKRestrictiveDataFilterManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D411319229F27DD002FF65A /* FBSDKRestrictiveDataFilterManager.h */; };
+		F483F3C9233AC13000703DE3 /* FBSDKCloseIcon.h in Headers */ = {isa = PBXBuildFile; fileRef = 89D652821A855A6000BB651C /* FBSDKCloseIcon.h */; };
+		F483F3CA233AC13000703DE3 /* _FBSDKTemporaryErrorRecoveryAttempter.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DF18BB71A9F1A05000F6748 /* _FBSDKTemporaryErrorRecoveryAttempter.h */; };
+		F483F3CB233AC13000703DE3 /* FBSDKCodelessMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = C5696F2E209BBC35009C931F /* FBSDKCodelessMacros.h */; };
+		F483F3CC233AC13000703DE3 /* FBSDKAppLinkTarget.h in Headers */ = {isa = PBXBuildFile; fileRef = 52963A72215992F300C7B252 /* FBSDKAppLinkTarget.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F3CD233AC13000703DE3 /* FBSDKViewHierarchy.h in Headers */ = {isa = PBXBuildFile; fileRef = C5696F2D209BBC35009C931F /* FBSDKViewHierarchy.h */; };
+		F483F3CE233AC13000703DE3 /* FBSDKProfile.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DA81AF41AA4EF3300B9FE0B /* FBSDKProfile.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F3CF233AC13000703DE3 /* FBSDKHybridAppEventsScriptMessageHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = C4FC99D7202CD5590038C5ED /* FBSDKHybridAppEventsScriptMessageHandler.h */; };
+		F483F3D0233AC13000703DE3 /* FBSDKWebViewAppLinkResolver.h in Headers */ = {isa = PBXBuildFile; fileRef = 52963A74215992F300C7B252 /* FBSDKWebViewAppLinkResolver.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F3D1233AC13000703DE3 /* FBSDKLibAnalyzer.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D9A704123261D6900BF9783 /* FBSDKLibAnalyzer.h */; };
+		F483F3D2233AC13000703DE3 /* FBSDKBridgeAPIProtocolWebV2.h in Headers */ = {isa = PBXBuildFile; fileRef = 89F203891AA960FA0053499E /* FBSDKBridgeAPIProtocolWebV2.h */; };
+		F483F3D3233AC13000703DE3 /* FBSDKInternalUtility.h in Headers */ = {isa = PBXBuildFile; fileRef = 893F44891A642F11001DB0B6 /* FBSDKInternalUtility.h */; };
+		F483F3D4233AC13000703DE3 /* FBSDKConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = 894C0B661A7150CC009137EF /* FBSDKConstants.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F3D5233AC13000703DE3 /* FBSDKURL.h in Headers */ = {isa = PBXBuildFile; fileRef = 52963A75215992F400C7B252 /* FBSDKURL.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F3D6233AC13000703DE3 /* FBSDKWebDialog.h in Headers */ = {isa = PBXBuildFile; fileRef = 89FB8C3F1A8425C4003CAE60 /* FBSDKWebDialog.h */; };
+		F483F3D7233AC13000703DE3 /* FBSDKMonotonicTime.h in Headers */ = {isa = PBXBuildFile; fileRef = ADEA17711B7ECA1A0070EDC0 /* FBSDKMonotonicTime.h */; };
+		F483F3D8233AC13000703DE3 /* FBSDKGraphRequestPiggybackManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DA81B271AA65FA200B9FE0B /* FBSDKGraphRequestPiggybackManager.h */; };
+		F483F3D9233AC13000703DE3 /* FBSDKCopying.h in Headers */ = {isa = PBXBuildFile; fileRef = 890414861A64893100617215 /* FBSDKCopying.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F3DA233AC13000703DE3 /* FBSDKViewImpressionTracker.h in Headers */ = {isa = PBXBuildFile; fileRef = 89688B601AA64C5E00A98519 /* FBSDKViewImpressionTracker.h */; };
+		F483F3DB233AC13000703DE3 /* FBSDKLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D6999FC1A76E166003AE384 /* FBSDKLogger.h */; };
+		F483F3DC233AC13000703DE3 /* FBSDKGateKeeperManager.h in Headers */ = {isa = PBXBuildFile; fileRef = F9FD9A6121659F120068DEAF /* FBSDKGateKeeperManager.h */; };
+		F483F3DD233AC13000703DE3 /* FBSDKError.h in Headers */ = {isa = PBXBuildFile; fileRef = 894C0B5F1A7150AC009137EF /* FBSDKError.h */; };
+		F483F3DE233AC13000703DE3 /* FBSDKServerConfigurationManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 89830F291A7805D100226ABB /* FBSDKServerConfigurationManager.h */; };
+		F483F3DF233AC13000703DE3 /* FBSDKAccessTokenExpirer.h in Headers */ = {isa = PBXBuildFile; fileRef = 033429B020894D4700C94913 /* FBSDKAccessTokenExpirer.h */; };
+		F483F3E0233AC13000703DE3 /* FBSDKGraphRequestMetadata.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DF2A3FD1A70572B00DFB2FD /* FBSDKGraphRequestMetadata.h */; };
+		F483F3E1233AC13000703DE3 /* FBSDKURL_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 52963A9D215993C100C7B252 /* FBSDKURL_Internal.h */; };
+		F483F3E2233AC13000703DE3 /* FBSDKGraphRequest+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DC6589A1A6EE5CD00B85AAF /* FBSDKGraphRequest+Internal.h */; };
+		F483F3E3233AC13000703DE3 /* FBSDKUtility.h in Headers */ = {isa = PBXBuildFile; fileRef = 89C8B1971A8D7A15009B07F5 /* FBSDKUtility.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F3E4233AC13000703DE3 /* FBSDKApplicationDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D34A11D1A5F038300C37317 /* FBSDKApplicationDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F3E5233AC13000703DE3 /* FBSDKColor.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DBA6A361A80267400B4DE6A /* FBSDKColor.h */; };
+		F483F3E6233AC13000703DE3 /* FBSDKDialogConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 89830F311A78060A00226ABB /* FBSDKDialogConfiguration.h */; };
+		F483F3E7233AC13000703DE3 /* FBSDKDeviceRequestsHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 520223F51D83C8D200CE0AB5 /* FBSDKDeviceRequestsHelper.h */; };
+		F483F3E8233AC13000703DE3 /* FBSDKUserDataStore.h in Headers */ = {isa = PBXBuildFile; fileRef = F9169B822155A02000FA1789 /* FBSDKUserDataStore.h */; };
+		F483F3E9233AC13000703DE3 /* FBSDKCodelessParameterComponent.h in Headers */ = {isa = PBXBuildFile; fileRef = C5696F32209BBC35009C931F /* FBSDKCodelessParameterComponent.h */; };
+		F483F3EA233AC13000703DE3 /* FBSDKAppLinkReturnToRefererView_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 52963A9B215993C100C7B252 /* FBSDKAppLinkReturnToRefererView_Internal.h */; };
+		F483F3EB233AC13000703DE3 /* FBSDKCrypto.h in Headers */ = {isa = PBXBuildFile; fileRef = 894C0B071A702194009137EF /* FBSDKCrypto.h */; };
+		F483F3EC233AC13000703DE3 /* FBSDKUIUtility.h in Headers */ = {isa = PBXBuildFile; fileRef = 89688B451AA62E3B00A98519 /* FBSDKUIUtility.h */; };
+		F483F3ED233AC13000703DE3 /* FBSDKDynamicFrameworkLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 81C969301C114723002FC037 /* FBSDKDynamicFrameworkLoader.h */; };
+		F483F3EE233AC13000703DE3 /* FBSDKKeychainStoreViaBundleID.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DE1F3CB1A89D9CD00B54D98 /* FBSDKKeychainStoreViaBundleID.h */; };
+		F483F3EF233AC13000703DE3 /* FBSDKAppLink_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 52963A9E215993C100C7B252 /* FBSDKAppLink_Internal.h */; };
+		F483F3F0233AC13000703DE3 /* FBSDKApplicationDelegate+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 894C0ACD1A6F0D3F009137EF /* FBSDKApplicationDelegate+Internal.h */; };
+		F483F3F1233AC13000703DE3 /* FBSDKBridgeAPIRequest+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 89D4AE851A7FFEFC00DB8C72 /* FBSDKBridgeAPIRequest+Private.h */; };
+		F483F3F2233AC13000703DE3 /* FBSDKGraphRequestConnection+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D69FC421AA66BBC0068EC76 /* FBSDKGraphRequestConnection+Internal.h */; };
+		F483F3F3233AC13000703DE3 /* FBSDKAppLink.h in Headers */ = {isa = PBXBuildFile; fileRef = 52963A70215992F200C7B252 /* FBSDKAppLink.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F3F4233AC13000703DE3 /* FBSDKButton+Subclass.h in Headers */ = {isa = PBXBuildFile; fileRef = 891687FC1AB38D2300F55364 /* FBSDKButton+Subclass.h */; };
+		F483F3F5233AC13000703DE3 /* FBSDKAccessToken.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D3029081A65C4420086B9ED /* FBSDKAccessToken.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F3F6233AC13000703DE3 /* FBSDKCoreKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D26974C1A5DF40700143BFC /* FBSDKCoreKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F3F7233AC13000703DE3 /* FBSDKGraphRequestBody.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DC658A01A6EE7E200B85AAF /* FBSDKGraphRequestBody.h */; };
+		F483F3F8233AC13000703DE3 /* FBSDKGraphRequestDataAttachment.h in Headers */ = {isa = PBXBuildFile; fileRef = 896DE2321A9E509300195731 /* FBSDKGraphRequestDataAttachment.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F3F9233AC13000703DE3 /* FBSDKSettings.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DA8303A1A6999EC00770955 /* FBSDKSettings.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F3FA233AC13000703DE3 /* FBSDKServerConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 89830F2D1A7805E100226ABB /* FBSDKServerConfiguration.h */; };
+		F483F3FB233AC13000703DE3 /* FBSDKAppEventsStateManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D0BC15D1A8D428700BE8BA4 /* FBSDKAppEventsStateManager.h */; };
+		F483F3FC233AC13000703DE3 /* FBSDKErrorRecoveryConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D3AF45E1A9EC24800EEF724 /* FBSDKErrorRecoveryConfiguration.h */; };
+		F483F3FD233AC13000703DE3 /* FBSDKAppEvents.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D0BC1551A8D23E200BE8BA4 /* FBSDKAppEvents.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F3FE233AC13000703DE3 /* FBSDKGraphRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DC658931A6EE5C500B85AAF /* FBSDKGraphRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F3FF233AC13000703DE3 /* FBSDKApplicationObserving.h in Headers */ = {isa = PBXBuildFile; fileRef = C5188DF8222F388400F4D8BC /* FBSDKApplicationObserving.h */; };
+		F483F400233AC13000703DE3 /* FBSDKBridgeAPIProtocolNativeV1.h in Headers */ = {isa = PBXBuildFile; fileRef = 894C0AF41A6F2278009137EF /* FBSDKBridgeAPIProtocolNativeV1.h */; };
+		F483F401233AC13000703DE3 /* FBSDKURLOpening.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D641F8B1A7E0EA10048F563 /* FBSDKURLOpening.h */; };
+		F483F402233AC13000703DE3 /* FBSDKMath.h in Headers */ = {isa = PBXBuildFile; fileRef = 893F44AA1A644744001DB0B6 /* FBSDKMath.h */; };
+		F483F403233AC13000703DE3 /* FBSDKCodelessIndexer.h in Headers */ = {isa = PBXBuildFile; fileRef = C5D25D3421795B790037B13D /* FBSDKCodelessIndexer.h */; };
+		F483F404233AC13000703DE3 /* FBSDKAppLinkReturnToRefererController.h in Headers */ = {isa = PBXBuildFile; fileRef = 52963A6E215992F200C7B252 /* FBSDKAppLinkReturnToRefererController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F405233AC13000703DE3 /* FBSDKCodelessPathComponent.h in Headers */ = {isa = PBXBuildFile; fileRef = C5696F2A209BBC35009C931F /* FBSDKCodelessPathComponent.h */; };
+		F483F406233AC13000703DE3 /* FBSDKURLSession.h in Headers */ = {isa = PBXBuildFile; fileRef = F9098FC122BC332C00857C2D /* FBSDKURLSession.h */; };
+		F483F407233AC13000703DE3 /* FBSDKGraphRequestConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DC6589C1A6EE7D800B85AAF /* FBSDKGraphRequestConnection.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F408233AC13000703DE3 /* FBSDKKeychainStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D32A83C1A69941A000A936D /* FBSDKKeychainStore.h */; };
+		F483F409233AC13000703DE3 /* FBSDKTestUsersManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D7E7E5F1ADF038800F53E38 /* FBSDKTestUsersManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F40A233AC13000703DE3 /* FBSDKFeatureManager.h in Headers */ = {isa = PBXBuildFile; fileRef = C5C7B74822D84F64004A5A0C /* FBSDKFeatureManager.h */; };
+		F483F40B233AC13000703DE3 /* FBSDKAppEventsDeviceInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 5F7063FA1AF733F300E42ED7 /* FBSDKAppEventsDeviceInfo.h */; };
+		F483F40C233AC13000703DE3 /* FBSDKAccessTokenCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D32A8431A699459000A936D /* FBSDKAccessTokenCache.h */; };
+		F483F40D233AC13000703DE3 /* FBSDKCrashObserving.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D4361142321C30400254DF7 /* FBSDKCrashObserving.h */; };
+		F483F40E233AC13000703DE3 /* FBSDKAppLinkNavigation.h in Headers */ = {isa = PBXBuildFile; fileRef = 52963A6A215992F100C7B252 /* FBSDKAppLinkNavigation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F40F233AC13000703DE3 /* (null) in Headers */ = {isa = PBXBuildFile; };
 		F487DADF231EBCD2008416A9 /* FBSDKGraphRequestPiggybackManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 9DA81B281AA65FA200B9FE0B /* FBSDKGraphRequestPiggybackManager.m */; };
 		F487DAE0231EBCD2008416A9 /* FBSDKAppEventsStateManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D0BC15E1A8D428700BE8BA4 /* FBSDKAppEventsStateManager.m */; };
 		F487DAE1231EBCD2008416A9 /* FBSDKServerConfigurationManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 89830F2A1A7805D100226ABB /* FBSDKServerConfigurationManager.m */; };
@@ -1500,6 +1719,7 @@
 		C5D25D3421795B790037B13D /* FBSDKCodelessIndexer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSDKCodelessIndexer.h; sourceTree = "<group>"; };
 		C5D25D3521795B790037B13D /* FBSDKCodelessIndexer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSDKCodelessIndexer.m; sourceTree = "<group>"; };
 		C5F6EC851FA24FAF009EB258 /* FBSDKPaymentObserverTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBSDKPaymentObserverTests.m; sourceTree = "<group>"; };
+		F483F414233AC13000703DE3 /* FBSDKCoreKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FBSDKCoreKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F487DBB9231EBCD2008416A9 /* FBSDKCoreKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FBSDKCoreKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F487DBCB231EC1A0008416A9 /* Permission.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Permission.swift; sourceTree = "<group>"; };
 		F487DBCD231EC20E008416A9 /* Settings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Settings.swift; sourceTree = "<group>"; };
@@ -1603,6 +1823,15 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F483F396233AC13000703DE3 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F483F397233AC13000703DE3 /* WebKit.framework in Frameworks */,
+				F483F398233AC13000703DE3 /* SafariServices.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2047,6 +2276,7 @@
 				C5C4B4D42276BA1200CA3706 /* FBSDKCoreKit.framework */,
 				C5C4B4EA2276BA8D00CA3706 /* FBSDKCoreKit.framework */,
 				F487DBB9231EBCD2008416A9 /* FBSDKCoreKit.framework */,
+				F483F414233AC13000703DE3 /* FBSDKCoreKit.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -2799,6 +3029,131 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		F483F399233AC13000703DE3 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F483F39A233AC13000703DE3 /* FBSDKAppLinkUtility.h in Headers */,
+				F483F39B233AC13000703DE3 /* FBSDKAppLinkResolver.h in Headers */,
+				F483F39C233AC13000703DE3 /* FBSDKAccessTokenCaching.h in Headers */,
+				F483F39D233AC13000703DE3 /* FBSDKBridgeAPIResponse.h in Headers */,
+				F483F39E233AC13000703DE3 /* FBSDKCoreKit+Internal.h in Headers */,
+				F483F39F233AC13000703DE3 /* FBSDKMeasurementEventListener.h in Headers */,
+				F483F3A0233AC13000703DE3 /* FBSDKAudioResourceLoader.h in Headers */,
+				F483F3A1233AC13000703DE3 /* FBSDKLogo.h in Headers */,
+				F483F3A2233AC13000703DE3 /* FBSDKMeasurementEvent.h in Headers */,
+				F483F3A3233AC13000703DE3 /* FBSDKProfilePictureView.h in Headers */,
+				F483F3A4233AC13000703DE3 /* FBSDKButton.h in Headers */,
+				F483F3A5233AC13000703DE3 /* FBSDKAppLinkResolving.h in Headers */,
+				F483F3A6233AC13000703DE3 /* FBSDKBridgeAPIProtocol.h in Headers */,
+				F483F3A7233AC13000703DE3 /* FBSDKEventBinding.h in Headers */,
+				F483F3A8233AC13000703DE3 /* FBSDKGraphErrorRecoveryProcessor.h in Headers */,
+				F483F3A9233AC13000703DE3 /* FBSDKBase64.h in Headers */,
+				F483F3AA233AC13000703DE3 /* FBSDKAppEventsUtility.h in Headers */,
+				F483F3AB233AC13000703DE3 /* FBSDKAppEvents+Internal.h in Headers */,
+				F483F3AC233AC13000703DE3 /* FBSDKImageDownloader.h in Headers */,
+				F483F3AD233AC13000703DE3 /* FBSDKBasicUtility.h in Headers */,
+				F483F3AE233AC13000703DE3 /* FBSDKErrorConfiguration.h in Headers */,
+				F483F3AF233AC13000703DE3 /* FBSDKTimeSpentData.h in Headers */,
+				F483F3B0233AC13000703DE3 /* FBSDKIcon.h in Headers */,
+				F483F3B1233AC13000703DE3 /* FBSDKAppLinkReturnToRefererView.h in Headers */,
+				F483F3B2233AC13000703DE3 /* FBSDKMeasurementEvent_Internal.h in Headers */,
+				F483F3B3233AC13000703DE3 /* FBSDKContainerViewController.h in Headers */,
+				F483F3B4233AC13000703DE3 /* FBSDKAppEventsState.h in Headers */,
+				F483F3B5233AC13000703DE3 /* FBSDKURLSessionTask.h in Headers */,
+				F483F3B6233AC13000703DE3 /* FBSDKBridgeAPIProtocolType.h in Headers */,
+				F483F3B7233AC13000703DE3 /* FBSDKMaleSilhouetteIcon.h in Headers */,
+				F483F3B8233AC13000703DE3 /* FBSDKCrashHandler.h in Headers */,
+				F483F3B9233AC13000703DE3 /* FBSDKCrashObserver.h in Headers */,
+				F483F3BA233AC13000703DE3 /* FBSDKMutableCopying.h in Headers */,
+				F483F3BB233AC13000703DE3 /* FBSDKTypeUtility.h in Headers */,
+				F483F3BC233AC13000703DE3 /* FBSDKSwizzler.h in Headers */,
+				F483F3BD233AC13000703DE3 /* FBSDKErrorRecoveryAttempter.h in Headers */,
+				F483F3BE233AC13000703DE3 /* FBSDKPaymentObserver.h in Headers */,
+				F483F3BF233AC13000703DE3 /* FBSDKProfile+Internal.h in Headers */,
+				F483F3C0233AC13000703DE3 /* FBSDKBridgeAPIProtocolWebV1.h in Headers */,
+				F483F3C1233AC13000703DE3 /* FBSDKBridgeAPI.h in Headers */,
+				F483F3C2233AC13000703DE3 /* FBSDKEventBindingManager.h in Headers */,
+				F483F3C3233AC13000703DE3 /* FBSDKBridgeAPIRequest.h in Headers */,
+				F483F3C4233AC13000703DE3 /* FBSDKWebDialogView.h in Headers */,
+				F483F3C5233AC13000703DE3 /* FBSDKInstrumentManager.h in Headers */,
+				F483F3C6233AC13000703DE3 /* FBSDKServerConfiguration+Internal.h in Headers */,
+				F483F3C7233AC13000703DE3 /* FBSDKTriStateBOOL.h in Headers */,
+				F483F3C8233AC13000703DE3 /* FBSDKRestrictiveDataFilterManager.h in Headers */,
+				F483F3C9233AC13000703DE3 /* FBSDKCloseIcon.h in Headers */,
+				F483F3CA233AC13000703DE3 /* _FBSDKTemporaryErrorRecoveryAttempter.h in Headers */,
+				F483F3CB233AC13000703DE3 /* FBSDKCodelessMacros.h in Headers */,
+				F483F3CC233AC13000703DE3 /* FBSDKAppLinkTarget.h in Headers */,
+				F483F3CD233AC13000703DE3 /* FBSDKViewHierarchy.h in Headers */,
+				F483F3CE233AC13000703DE3 /* FBSDKProfile.h in Headers */,
+				F483F3CF233AC13000703DE3 /* FBSDKHybridAppEventsScriptMessageHandler.h in Headers */,
+				F483F3D0233AC13000703DE3 /* FBSDKWebViewAppLinkResolver.h in Headers */,
+				F483F3D1233AC13000703DE3 /* FBSDKLibAnalyzer.h in Headers */,
+				F483F3D2233AC13000703DE3 /* FBSDKBridgeAPIProtocolWebV2.h in Headers */,
+				F483F3D3233AC13000703DE3 /* FBSDKInternalUtility.h in Headers */,
+				F483F3D4233AC13000703DE3 /* FBSDKConstants.h in Headers */,
+				F483F3D5233AC13000703DE3 /* FBSDKURL.h in Headers */,
+				F483F3D6233AC13000703DE3 /* FBSDKWebDialog.h in Headers */,
+				F483F3D7233AC13000703DE3 /* FBSDKMonotonicTime.h in Headers */,
+				F483F3D8233AC13000703DE3 /* FBSDKGraphRequestPiggybackManager.h in Headers */,
+				F483F3D9233AC13000703DE3 /* FBSDKCopying.h in Headers */,
+				F483F3DA233AC13000703DE3 /* FBSDKViewImpressionTracker.h in Headers */,
+				F483F3DB233AC13000703DE3 /* FBSDKLogger.h in Headers */,
+				F483F3DC233AC13000703DE3 /* FBSDKGateKeeperManager.h in Headers */,
+				F483F3DD233AC13000703DE3 /* FBSDKError.h in Headers */,
+				F483F3DE233AC13000703DE3 /* FBSDKServerConfigurationManager.h in Headers */,
+				F483F3DF233AC13000703DE3 /* FBSDKAccessTokenExpirer.h in Headers */,
+				F483F3E0233AC13000703DE3 /* FBSDKGraphRequestMetadata.h in Headers */,
+				F483F3E1233AC13000703DE3 /* FBSDKURL_Internal.h in Headers */,
+				F483F3E2233AC13000703DE3 /* FBSDKGraphRequest+Internal.h in Headers */,
+				F483F3E3233AC13000703DE3 /* FBSDKUtility.h in Headers */,
+				F483F3E4233AC13000703DE3 /* FBSDKApplicationDelegate.h in Headers */,
+				F483F3E5233AC13000703DE3 /* FBSDKColor.h in Headers */,
+				F483F3E6233AC13000703DE3 /* FBSDKDialogConfiguration.h in Headers */,
+				F483F3E7233AC13000703DE3 /* FBSDKDeviceRequestsHelper.h in Headers */,
+				F483F3E8233AC13000703DE3 /* FBSDKUserDataStore.h in Headers */,
+				F483F3E9233AC13000703DE3 /* FBSDKCodelessParameterComponent.h in Headers */,
+				F483F3EA233AC13000703DE3 /* FBSDKAppLinkReturnToRefererView_Internal.h in Headers */,
+				F483F3EB233AC13000703DE3 /* FBSDKCrypto.h in Headers */,
+				F483F3EC233AC13000703DE3 /* FBSDKUIUtility.h in Headers */,
+				F483F3ED233AC13000703DE3 /* FBSDKDynamicFrameworkLoader.h in Headers */,
+				F483F3EE233AC13000703DE3 /* FBSDKKeychainStoreViaBundleID.h in Headers */,
+				F483F3EF233AC13000703DE3 /* FBSDKAppLink_Internal.h in Headers */,
+				F483F3F0233AC13000703DE3 /* FBSDKApplicationDelegate+Internal.h in Headers */,
+				F483F3F1233AC13000703DE3 /* FBSDKBridgeAPIRequest+Private.h in Headers */,
+				F483F3F2233AC13000703DE3 /* FBSDKGraphRequestConnection+Internal.h in Headers */,
+				F483F3F3233AC13000703DE3 /* FBSDKAppLink.h in Headers */,
+				F483F3F4233AC13000703DE3 /* FBSDKButton+Subclass.h in Headers */,
+				F483F3F5233AC13000703DE3 /* FBSDKAccessToken.h in Headers */,
+				F483F3F6233AC13000703DE3 /* FBSDKCoreKit.h in Headers */,
+				F483F3F7233AC13000703DE3 /* FBSDKGraphRequestBody.h in Headers */,
+				F483F3F8233AC13000703DE3 /* FBSDKGraphRequestDataAttachment.h in Headers */,
+				F483F3F9233AC13000703DE3 /* FBSDKSettings.h in Headers */,
+				F483F3FA233AC13000703DE3 /* FBSDKServerConfiguration.h in Headers */,
+				F483F3FB233AC13000703DE3 /* FBSDKAppEventsStateManager.h in Headers */,
+				F483F3FC233AC13000703DE3 /* FBSDKErrorRecoveryConfiguration.h in Headers */,
+				F483F3FD233AC13000703DE3 /* FBSDKAppEvents.h in Headers */,
+				F483F3FE233AC13000703DE3 /* FBSDKGraphRequest.h in Headers */,
+				F483F3FF233AC13000703DE3 /* FBSDKApplicationObserving.h in Headers */,
+				F483F400233AC13000703DE3 /* FBSDKBridgeAPIProtocolNativeV1.h in Headers */,
+				F483F401233AC13000703DE3 /* FBSDKURLOpening.h in Headers */,
+				F483F402233AC13000703DE3 /* FBSDKMath.h in Headers */,
+				F483F403233AC13000703DE3 /* FBSDKCodelessIndexer.h in Headers */,
+				F483F404233AC13000703DE3 /* FBSDKAppLinkReturnToRefererController.h in Headers */,
+				F483F405233AC13000703DE3 /* FBSDKCodelessPathComponent.h in Headers */,
+				F483F406233AC13000703DE3 /* FBSDKURLSession.h in Headers */,
+				F483F407233AC13000703DE3 /* FBSDKGraphRequestConnection.h in Headers */,
+				F483F408233AC13000703DE3 /* FBSDKKeychainStore.h in Headers */,
+				F483F409233AC13000703DE3 /* FBSDKTestUsersManager.h in Headers */,
+				F483F40A233AC13000703DE3 /* FBSDKFeatureManager.h in Headers */,
+				F483F40B233AC13000703DE3 /* FBSDKAppEventsDeviceInfo.h in Headers */,
+				F483F40C233AC13000703DE3 /* FBSDKAccessTokenCache.h in Headers */,
+				F483F40D233AC13000703DE3 /* FBSDKCrashObserving.h in Headers */,
+				F483F40E233AC13000703DE3 /* FBSDKAppLinkNavigation.h in Headers */,
+				F483F40F233AC13000703DE3 /* (null) in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		F487DB3F231EBCD2008416A9 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -3090,6 +3445,24 @@
 			productReference = C5C4B4EA2276BA8D00CA3706 /* FBSDKCoreKit.framework */;
 			productType = "com.apple.product-type.framework";
 		};
+		F483F331233AC13000703DE3 /* FBSDKCoreKitSwift-Dynamic */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F483F411233AC13000703DE3 /* Build configuration list for PBXNativeTarget "FBSDKCoreKitSwift-Dynamic" */;
+			buildPhases = (
+				F483F332233AC13000703DE3 /* Sources */,
+				F483F396233AC13000703DE3 /* Frameworks */,
+				F483F399233AC13000703DE3 /* Headers */,
+				F483F410233AC13000703DE3 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "FBSDKCoreKitSwift-Dynamic";
+			productName = FBSDKCoreKit;
+			productReference = F483F414233AC13000703DE3 /* FBSDKCoreKit.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 		F487DADD231EBCD2008416A9 /* FBSDKCoreKitSwift */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = F487DBB6231EBCD2008416A9 /* Build configuration list for PBXNativeTarget "FBSDKCoreKitSwift" */;
@@ -3172,6 +3545,7 @@
 				C5C4B4DC2276BA8D00CA3706 /* FBSDKCoreKit_Basics_TV-Dynamic */,
 				C5FCE332228E08D400867DFD /* FBSDKCoreKit_Basics_TV-Universal */,
 				F487DADD231EBCD2008416A9 /* FBSDKCoreKitSwift */,
+				F483F331233AC13000703DE3 /* FBSDKCoreKitSwift-Dynamic */,
 			);
 		};
 /* End PBXProject section */
@@ -3335,6 +3709,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		C5C4B4E62276BA8D00CA3706 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F483F410233AC13000703DE3 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -3826,6 +4207,112 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		F483F332233AC13000703DE3 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F483F333233AC13000703DE3 /* FBSDKGraphRequestPiggybackManager.m in Sources */,
+				F483F334233AC13000703DE3 /* FBSDKAppEventsStateManager.m in Sources */,
+				F483F335233AC13000703DE3 /* FBSDKServerConfigurationManager.m in Sources */,
+				F483F336233AC13000703DE3 /* FBSDKGraphRequest.m in Sources */,
+				F483F337233AC13000703DE3 /* FBSDKContainerViewController.m in Sources */,
+				F483F338233AC13000703DE3 /* FBSDKHybridAppEventsScriptMessageHandler.m in Sources */,
+				F483F339233AC13000703DE3 /* FBSDKAccessTokenCache.m in Sources */,
+				F483F33A233AC13000703DE3 /* FBSDKCrypto.m in Sources */,
+				F483F33B233AC13000703DE3 /* FBSDKAppEventsState.m in Sources */,
+				F483F33C233AC13000703DE3 /* FBSDKCloseIcon.m in Sources */,
+				F483F33D233AC13000703DE3 /* Dictionary+KeyValueMap.swift in Sources */,
+				F483F33E233AC13000703DE3 /* FBSDKWebViewAppLinkResolver.m in Sources */,
+				F483F33F233AC13000703DE3 /* FBSDKRestrictiveDataFilterManager.m in Sources */,
+				F483F340233AC13000703DE3 /* FBSDKBase64.m in Sources */,
+				F483F341233AC13000703DE3 /* FBSDKBridgeAPIProtocolWebV2.m in Sources */,
+				F483F342233AC13000703DE3 /* FBSDKGraphRequestBody.m in Sources */,
+				F483F343233AC13000703DE3 /* FBSDKUtility.m in Sources */,
+				F483F344233AC13000703DE3 /* FBSDKTestUsersManager.m in Sources */,
+				F483F345233AC13000703DE3 /* FBSDKMeasurementEventListener.m in Sources */,
+				F483F346233AC13000703DE3 /* FBSDKProfilePictureView.m in Sources */,
+				F483F347233AC13000703DE3 /* FBSDKTriStateBOOL.m in Sources */,
+				F483F348233AC13000703DE3 /* FBSDKLogger.m in Sources */,
+				F483F349233AC13000703DE3 /* FBSDKApplicationDelegate.m in Sources */,
+				F483F34A233AC13000703DE3 /* FBSDKBridgeAPI.m in Sources */,
+				F483F34B233AC13000703DE3 /* Permission.swift in Sources */,
+				F483F34C233AC13000703DE3 /* FBSDKDynamicFrameworkLoader.m in Sources */,
+				F483F34D233AC13000703DE3 /* FBSDKAppLinkNavigation.m in Sources */,
+				F483F34E233AC13000703DE3 /* FBSDKGraphRequestDataAttachment.m in Sources */,
+				F483F34F233AC13000703DE3 /* FBSDKDialogConfiguration.m in Sources */,
+				F483F350233AC13000703DE3 /* FBSDKSwizzler.m in Sources */,
+				F483F351233AC13000703DE3 /* FBSDKAccessToken.m in Sources */,
+				F483F352233AC13000703DE3 /* FBSDKURL.m in Sources */,
+				F483F353233AC13000703DE3 /* FBSDKInternalUtility.m in Sources */,
+				F483F354233AC13000703DE3 /* FBSDKMonotonicTime.m in Sources */,
+				F483F355233AC13000703DE3 /* FBSDKAppLinkUtility.m in Sources */,
+				F483F356233AC13000703DE3 /* FBSDKViewImpressionTracker.m in Sources */,
+				F483F357233AC13000703DE3 /* FBSDKLibAnalyzer.m in Sources */,
+				F483F358233AC13000703DE3 /* FBSDKImageDownloader.m in Sources */,
+				F483F359233AC13000703DE3 /* FBSDKBridgeAPIRequest.m in Sources */,
+				F483F35A233AC13000703DE3 /* FBSDKViewHierarchy.m in Sources */,
+				F483F35B233AC13000703DE3 /* FBSDKCodelessParameterComponent.m in Sources */,
+				F483F35C233AC13000703DE3 /* FBSDKBasicUtility.m in Sources */,
+				F483F35D233AC13000703DE3 /* FBSDKAppEventsDeviceInfo.m in Sources */,
+				F483F35E233AC13000703DE3 /* FBSDKError.m in Sources */,
+				F483F35F233AC13000703DE3 /* FBSDKAudioResourceLoader.m in Sources */,
+				F483F360233AC13000703DE3 /* FBSDKLogo.m in Sources */,
+				F483F361233AC13000703DE3 /* FBSDKPaymentObserver.m in Sources */,
+				F483F362233AC13000703DE3 /* FBSDKBridgeAPIResponse.m in Sources */,
+				F483F363233AC13000703DE3 /* FBSDKCrashHandler.m in Sources */,
+				F483F364233AC13000703DE3 /* FBSDKErrorRecoveryConfiguration.m in Sources */,
+				F483F365233AC13000703DE3 /* FBProfilePictureView.swift in Sources */,
+				F483F366233AC13000703DE3 /* FBSDKGraphErrorRecoveryProcessor.m in Sources */,
+				F483F367233AC13000703DE3 /* FBSDKAppLinkReturnToRefererController.m in Sources */,
+				F483F368233AC13000703DE3 /* FBSDKTimeSpentData.m in Sources */,
+				F483F369233AC13000703DE3 /* FBSDKBridgeAPIProtocolWebV1.m in Sources */,
+				F483F36A233AC13000703DE3 /* FBSDKMath.m in Sources */,
+				F483F36B233AC13000703DE3 /* FBSDKWebDialog.m in Sources */,
+				F483F36C233AC13000703DE3 /* FBSDKEventBinding.m in Sources */,
+				F483F36D233AC13000703DE3 /* FBSDKAccessTokenExpirer.m in Sources */,
+				F483F36E233AC13000703DE3 /* FBSDKTypeUtility.m in Sources */,
+				F483F36F233AC13000703DE3 /* FBSDKColor.m in Sources */,
+				F483F370233AC13000703DE3 /* FBSDKAppLinkResolver.m in Sources */,
+				F483F371233AC13000703DE3 /* FBSDKIcon.m in Sources */,
+				F483F372233AC13000703DE3 /* FBSDKConstants.m in Sources */,
+				F483F373233AC13000703DE3 /* FBSDKAppEventsUtility.m in Sources */,
+				F483F374233AC13000703DE3 /* AccessToken.swift in Sources */,
+				F483F375233AC13000703DE3 /* FBSDKInstrumentManager.m in Sources */,
+				F483F376233AC13000703DE3 /* FBSDKCodelessPathComponent.m in Sources */,
+				F483F377233AC13000703DE3 /* FBSDKSettings.m in Sources */,
+				F483F378233AC13000703DE3 /* FBSDKAppLink.m in Sources */,
+				F483F379233AC13000703DE3 /* FBSDKAppLinkReturnToRefererView.m in Sources */,
+				F483F37A233AC13000703DE3 /* FBSDKButton.m in Sources */,
+				F483F37B233AC13000703DE3 /* FBSDKCodelessIndexer.m in Sources */,
+				F483F37C233AC13000703DE3 /* FBSDKGraphRequestMetadata.m in Sources */,
+				F483F37D233AC13000703DE3 /* FBSDKErrorRecoveryAttempter.m in Sources */,
+				F483F37E233AC13000703DE3 /* FBSDKAppLinkTarget.m in Sources */,
+				F483F37F233AC13000703DE3 /* FBSDKProfile.m in Sources */,
+				F483F380233AC13000703DE3 /* FBSDKEventBindingManager.m in Sources */,
+				F483F381233AC13000703DE3 /* (null) in Sources */,
+				F483F382233AC13000703DE3 /* FBSDKKeychainStore.m in Sources */,
+				F483F383233AC13000703DE3 /* FBSDKGraphRequestConnection.m in Sources */,
+				F483F384233AC13000703DE3 /* FBSDKAppEvents.m in Sources */,
+				F483F385233AC13000703DE3 /* FBSDKGateKeeperManager.m in Sources */,
+				F483F386233AC13000703DE3 /* FBSDKUserDataStore.m in Sources */,
+				F483F387233AC13000703DE3 /* FBSDKURLSession.m in Sources */,
+				F483F388233AC13000703DE3 /* _FBSDKTemporaryErrorRecoveryAttempter.m in Sources */,
+				F483F389233AC13000703DE3 /* FBSDKMeasurementEvent.m in Sources */,
+				F483F38A233AC13000703DE3 /* FBSDKBridgeAPIProtocolNativeV1.m in Sources */,
+				F483F38B233AC13000703DE3 /* FBSDKCrashObserver.m in Sources */,
+				F483F38C233AC13000703DE3 /* FBSDKWebDialogView.m in Sources */,
+				F483F38D233AC13000703DE3 /* FBSDKErrorConfiguration.m in Sources */,
+				F483F38E233AC13000703DE3 /* FBSDKDeviceRequestsHelper.m in Sources */,
+				F483F38F233AC13000703DE3 /* FBSDKKeychainStoreViaBundleID.m in Sources */,
+				F483F390233AC13000703DE3 /* Settings.swift in Sources */,
+				F483F391233AC13000703DE3 /* FBSDKServerConfiguration.m in Sources */,
+				F483F392233AC13000703DE3 /* FBSDKErrorReport.m in Sources */,
+				F483F393233AC13000703DE3 /* FBSDKMaleSilhouetteIcon.m in Sources */,
+				F483F394233AC13000703DE3 /* FBSDKFeatureManager.m in Sources */,
+				F483F395233AC13000703DE3 /* FBSDKURLSessionTask.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		F487DADE231EBCD2008416A9 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -4211,6 +4698,39 @@
 			};
 			name = Release;
 		};
+		F483F412233AC13000703DE3 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 81A4A6031D19BE0400D5BF66 /* FBSDKCoreKit.xcconfig */;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = NO;
+				DEFINES_MODULE = YES;
+				"FB_BITCODE_FLAG[sdk=iphoneos11.0]" = "-fembed-bitcode";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = mh_dylib;
+				PRODUCT_MODULE_NAME = FBSDKCoreKit;
+				PRODUCT_NAME = FBSDKCoreKit;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		F483F413233AC13000703DE3 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 81A4A6031D19BE0400D5BF66 /* FBSDKCoreKit.xcconfig */;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = NO;
+				DEFINES_MODULE = YES;
+				"FB_BITCODE_FLAG[sdk=iphoneos11.0]" = "-fembed-bitcode";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = mh_dylib;
+				PRODUCT_MODULE_NAME = FBSDKCoreKit;
+				PRODUCT_NAME = FBSDKCoreKit;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
 		F487DBB7231EBCD2008416A9 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 81A4A6031D19BE0400D5BF66 /* FBSDKCoreKit.xcconfig */;
@@ -4365,6 +4885,15 @@
 			buildConfigurations = (
 				C5FCE337228E08D400867DFD /* Debug */,
 				C5FCE338228E08D400867DFD /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		F483F411233AC13000703DE3 /* Build configuration list for PBXNativeTarget "FBSDKCoreKitSwift-Dynamic" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F483F412233AC13000703DE3 /* Debug */,
+				F483F413233AC13000703DE3 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/FBSDKCoreKit/FBSDKCoreKit/Swift/FBSDKCoreKitSwift-Dynamic.xcscheme
+++ b/FBSDKCoreKit/FBSDKCoreKit/Swift/FBSDKCoreKitSwift-Dynamic.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1030"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F483F331233AC13000703DE3"
+               BuildableName = "FBSDKCoreKit.framework"
+               BlueprintName = "FBSDKCoreKitSwift-Dynamic"
+               ReferencedContainer = "container:FBSDKCoreKit.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F483F331233AC13000703DE3"
+            BuildableName = "FBSDKCoreKit.framework"
+            BlueprintName = "FBSDKCoreKitSwift-Dynamic"
+            ReferencedContainer = "container:FBSDKCoreKit.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F483F331233AC13000703DE3"
+            BuildableName = "FBSDKCoreKit.framework"
+            BlueprintName = "FBSDKCoreKitSwift-Dynamic"
+            ReferencedContainer = "container:FBSDKCoreKit.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/FBSDKLoginKit/FBSDKLoginKit.xcodeproj/project.pbxproj
+++ b/FBSDKLoginKit/FBSDKLoginKit.xcodeproj/project.pbxproj
@@ -131,6 +131,38 @@
 		9DDFBB721A829503006C9208 /* FBSDKTooltipView.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DDFBB701A829503006C9208 /* FBSDKTooltipView.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9DDFBB731A829503006C9208 /* FBSDKTooltipView.m in Sources */ = {isa = PBXBuildFile; fileRef = 9DDFBB711A829503006C9208 /* FBSDKTooltipView.m */; };
 		9DEE5C941A671B5500D750E1 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9DEE5C931A671B5500D750E1 /* XCTest.framework */; };
+		F483F427233AC85F00703DE3 /* FBSDKLoginButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D65ACA71A803FF200E375C2 /* FBSDKLoginButton.m */; };
+		F483F428233AC85F00703DE3 /* LoginManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F487DC14231EC3EF008416A9 /* LoginManager.swift */; };
+		F483F429233AC85F00703DE3 /* FBSDKLoginCompletion.m in Sources */ = {isa = PBXBuildFile; fileRef = 6B5D2DED1A8EB1D200D3EF09 /* FBSDKLoginCompletion.m */; };
+		F483F42A233AC85F00703DE3 /* FBSDKLoginConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D03E8331A72DF5800207493 /* FBSDKLoginConstants.m */; };
+		F483F42B233AC85F00703DE3 /* FBSDKLoginError.m in Sources */ = {isa = PBXBuildFile; fileRef = 6B5D2DE91A8D91B200D3EF09 /* FBSDKLoginError.m */; };
+		F483F42C233AC85F00703DE3 /* FBLoginButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = F487DC13231EC3EF008416A9 /* FBLoginButton.swift */; };
+		F483F42D233AC85F00703DE3 /* FBSDKLoginManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D03E8201A72D7E700207493 /* FBSDKLoginManager.m */; };
+		F483F42E233AC85F00703DE3 /* FBSDKLoginManagerLoginResult.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D03E8241A72D89100207493 /* FBSDKLoginManagerLoginResult.m */; };
+		F483F42F233AC85F00703DE3 /* FBSDKLoginTooltipView.m in Sources */ = {isa = PBXBuildFile; fileRef = 9DBA6A281A80252F00B4DE6A /* FBSDKLoginTooltipView.m */; };
+		F483F430233AC85F00703DE3 /* FBSDKLoginUtility.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D03E8291A72DCE300207493 /* FBSDKLoginUtility.m */; };
+		F483F431233AC85F00703DE3 /* FBSDKDeviceLoginManagerResult.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B9DBF06207C051800662776 /* FBSDKDeviceLoginManagerResult.m */; };
+		F483F432233AC85F00703DE3 /* FBSDKTooltipView.m in Sources */ = {isa = PBXBuildFile; fileRef = 9DDFBB711A829503006C9208 /* FBSDKTooltipView.m */; };
+		F483F433233AC85F00703DE3 /* FBSDKDeviceLoginManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B9DBF09207C051800662776 /* FBSDKDeviceLoginManager.m */; };
+		F483F434233AC85F00703DE3 /* _FBSDKLoginRecoveryAttempter.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D3AF4921A9EFEFB00EEF724 /* _FBSDKLoginRecoveryAttempter.m */; };
+		F483F435233AC85F00703DE3 /* FBSDKLoginManagerLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 6B34A7EC1ABA4E6B00AF9858 /* FBSDKLoginManagerLogger.m */; };
+		F483F436233AC85F00703DE3 /* FBSDKDeviceLoginCodeInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B9DBF02207C051700662776 /* FBSDKDeviceLoginCodeInfo.m */; };
+		F483F439233AC85F00703DE3 /* FBSDKDeviceLoginCodeInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 0B9DBF08207C051800662776 /* FBSDKDeviceLoginCodeInfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F43A233AC85F00703DE3 /* FBSDKDeviceLoginManagerResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 0B9DBF05207C051800662776 /* FBSDKDeviceLoginManagerResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F43B233AC85F00703DE3 /* FBSDKDeviceLoginManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 0B9DBF04207C051800662776 /* FBSDKDeviceLoginManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F43C233AC85F00703DE3 /* _FBSDKLoginRecoveryAttempter.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D3AF4911A9EFEFB00EEF724 /* _FBSDKLoginRecoveryAttempter.h */; };
+		F483F43D233AC85F00703DE3 /* FBSDKCoreKit+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DBC4C3B1A782E2000816FE8 /* FBSDKCoreKit+Internal.h */; };
+		F483F43E233AC85F00703DE3 /* FBSDKLoginConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D03E8321A72DF5800207493 /* FBSDKLoginConstants.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F43F233AC85F00703DE3 /* FBSDKLoginKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D9DB8DE1A114E500086167B /* FBSDKLoginKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F440233AC85F00703DE3 /* FBSDKLoginManagerLoginResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D03E8231A72D89100207493 /* FBSDKLoginManagerLoginResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F441233AC85F00703DE3 /* FBSDKTooltipView.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DDFBB701A829503006C9208 /* FBSDKTooltipView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F442233AC85F00703DE3 /* FBSDKDeviceLoginCodeInfo+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 0B9DBEFD207C04FF00662776 /* FBSDKDeviceLoginCodeInfo+Internal.h */; };
+		F483F443233AC85F00703DE3 /* FBSDKLoginButton.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D65ACA61A803FF200E375C2 /* FBSDKLoginButton.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F444233AC85F00703DE3 /* FBSDKLoginTooltipView.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DBA6A2C1A80253F00B4DE6A /* FBSDKLoginTooltipView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F445233AC85F00703DE3 /* FBSDKLoginUtility.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D03E8281A72DCE300207493 /* FBSDKLoginUtility.h */; };
+		F483F446233AC85F00703DE3 /* FBSDKLoginCompletion.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B5D2DEC1A8EB1D200D3EF09 /* FBSDKLoginCompletion.h */; };
+		F483F447233AC85F00703DE3 /* FBSDKLoginManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D03E81F1A72D7E700207493 /* FBSDKLoginManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F448233AC85F00703DE3 /* FBSDKDeviceLoginManagerResult+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 0B9DBEF7207C04FF00662776 /* FBSDKDeviceLoginManagerResult+Internal.h */; };
 		F487DBDF231EC34B008416A9 /* FBSDKLoginButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D65ACA71A803FF200E375C2 /* FBSDKLoginButton.m */; };
 		F487DBE0231EC34B008416A9 /* FBSDKLoginCompletion.m in Sources */ = {isa = PBXBuildFile; fileRef = 6B5D2DED1A8EB1D200D3EF09 /* FBSDKLoginCompletion.m */; };
 		F487DBE1231EC34B008416A9 /* FBSDKLoginConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D03E8331A72DF5800207493 /* FBSDKLoginConstants.m */; };
@@ -285,6 +317,20 @@
 			remoteGlobalIDString = 9D9DB8D81A114E500086167B;
 			remoteInfo = FBSDKLoginKit;
 		};
+		F483F425233AC85F00703DE3 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8118B6781D0A5B9400962084 /* FBSDKCoreKit.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = F487DADD231EBCD2008416A9;
+			remoteInfo = FBSDKCoreKitSwift;
+		};
+		F483F459233AC85F00703DE3 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8118B6781D0A5B9400962084 /* FBSDKCoreKit.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = F483F414233AC13000703DE3;
+			remoteInfo = "FBSDKCoreKitSwift-Dynamic";
+		};
 		F487DC0E231EC34B008416A9 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 8118B6781D0A5B9400962084 /* FBSDKCoreKit.xcodeproj */;
@@ -384,6 +430,7 @@
 		9DDFBB701A829503006C9208 /* FBSDKTooltipView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSDKTooltipView.h; sourceTree = "<group>"; };
 		9DDFBB711A829503006C9208 /* FBSDKTooltipView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSDKTooltipView.m; sourceTree = "<group>"; };
 		9DEE5C931A671B5500D750E1 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneSimulator.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
+		F483F44D233AC85F00703DE3 /* FBSDKLoginKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FBSDKLoginKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F487DC03231EC34B008416A9 /* FBSDKLoginKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FBSDKLoginKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F487DC13231EC3EF008416A9 /* FBLoginButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FBLoginButton.swift; sourceTree = "<group>"; };
 		F487DC14231EC3EF008416A9 /* LoginManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginManager.swift; sourceTree = "<group>"; };
@@ -438,6 +485,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		F483F437233AC85F00703DE3 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		F487DBED231EC34B008416A9 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -461,6 +515,7 @@
 				5E309CB0228F2581007B532E /* FBSDKCoreKit.framework */,
 				5E309CB2228F2581007B532E /* FBSDKCoreKit.framework */,
 				F487DC0F231EC34B008416A9 /* FBSDKCoreKit.framework */,
+				F483F45A233AC85F00703DE3 /* FBSDKCoreKit.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -593,6 +648,7 @@
 				0B9DBF2C207C05CD00662776 /* FBSDKLoginKit.framework */,
 				0B9DBF52207C07C600662776 /* FBSDKLoginKit.framework */,
 				F487DC03231EC34B008416A9 /* FBSDKLoginKit.framework */,
+				F483F44D233AC85F00703DE3 /* FBSDKLoginKit.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -739,6 +795,29 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		F483F438233AC85F00703DE3 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F483F439233AC85F00703DE3 /* FBSDKDeviceLoginCodeInfo.h in Headers */,
+				F483F43A233AC85F00703DE3 /* FBSDKDeviceLoginManagerResult.h in Headers */,
+				F483F43B233AC85F00703DE3 /* FBSDKDeviceLoginManager.h in Headers */,
+				F483F43C233AC85F00703DE3 /* _FBSDKLoginRecoveryAttempter.h in Headers */,
+				F483F43D233AC85F00703DE3 /* FBSDKCoreKit+Internal.h in Headers */,
+				F483F43E233AC85F00703DE3 /* FBSDKLoginConstants.h in Headers */,
+				F483F43F233AC85F00703DE3 /* FBSDKLoginKit.h in Headers */,
+				F483F440233AC85F00703DE3 /* FBSDKLoginManagerLoginResult.h in Headers */,
+				F483F441233AC85F00703DE3 /* FBSDKTooltipView.h in Headers */,
+				F483F442233AC85F00703DE3 /* FBSDKDeviceLoginCodeInfo+Internal.h in Headers */,
+				F483F443233AC85F00703DE3 /* FBSDKLoginButton.h in Headers */,
+				F483F444233AC85F00703DE3 /* FBSDKLoginTooltipView.h in Headers */,
+				F483F445233AC85F00703DE3 /* FBSDKLoginUtility.h in Headers */,
+				F483F446233AC85F00703DE3 /* FBSDKLoginCompletion.h in Headers */,
+				F483F447233AC85F00703DE3 /* FBSDKLoginManager.h in Headers */,
+				F483F448233AC85F00703DE3 /* FBSDKDeviceLoginManagerResult+Internal.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		F487DBEE231EC34B008416A9 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -860,6 +939,25 @@
 			productReference = 9D9DB8E41A114E500086167B /* FBSDKLoginKitTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		F483F423233AC85F00703DE3 /* FBSDKLoginKitSwift-Dynamic */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F483F44A233AC85F00703DE3 /* Build configuration list for PBXNativeTarget "FBSDKLoginKitSwift-Dynamic" */;
+			buildPhases = (
+				F483F426233AC85F00703DE3 /* Sources */,
+				F483F437233AC85F00703DE3 /* Frameworks */,
+				F483F438233AC85F00703DE3 /* Headers */,
+				F483F449233AC85F00703DE3 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				F483F424233AC85F00703DE3 /* PBXTargetDependency */,
+			);
+			name = "FBSDKLoginKitSwift-Dynamic";
+			productName = FBSDKLoginKit;
+			productReference = F483F44D233AC85F00703DE3 /* FBSDKLoginKit.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 		F487DBDB231EC34B008416A9 /* FBSDKLoginKitSwift */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = F487DC00231EC34B008416A9 /* Build configuration list for PBXNativeTarget "FBSDKLoginKitSwift" */;
@@ -932,6 +1030,7 @@
 				0B9DBF40207C07C600662776 /* FBSDKLoginKit_TV-Dynamic */,
 				0B9DBF6E207C0B5C00662776 /* FBSDKLoginKit_TV-Universal */,
 				F487DBDB231EC34B008416A9 /* FBSDKLoginKitSwift */,
+				F483F423233AC85F00703DE3 /* FBSDKLoginKitSwift-Dynamic */,
 			);
 		};
 /* End PBXProject section */
@@ -1000,6 +1099,13 @@
 			remoteRef = 817490FE1D1C6C11006E09DF /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
+		F483F45A233AC85F00703DE3 /* FBSDKCoreKit.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = FBSDKCoreKit.framework;
+			remoteRef = F483F459233AC85F00703DE3 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
 		F487DC0F231EC34B008416A9 /* FBSDKCoreKit.framework */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.framework;
@@ -1039,6 +1145,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		9D9DB8E21A114E500086167B /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F483F449233AC85F00703DE3 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1157,6 +1270,29 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		F483F426233AC85F00703DE3 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F483F427233AC85F00703DE3 /* FBSDKLoginButton.m in Sources */,
+				F483F428233AC85F00703DE3 /* LoginManager.swift in Sources */,
+				F483F429233AC85F00703DE3 /* FBSDKLoginCompletion.m in Sources */,
+				F483F42A233AC85F00703DE3 /* FBSDKLoginConstants.m in Sources */,
+				F483F42B233AC85F00703DE3 /* FBSDKLoginError.m in Sources */,
+				F483F42C233AC85F00703DE3 /* FBLoginButton.swift in Sources */,
+				F483F42D233AC85F00703DE3 /* FBSDKLoginManager.m in Sources */,
+				F483F42E233AC85F00703DE3 /* FBSDKLoginManagerLoginResult.m in Sources */,
+				F483F42F233AC85F00703DE3 /* FBSDKLoginTooltipView.m in Sources */,
+				F483F430233AC85F00703DE3 /* FBSDKLoginUtility.m in Sources */,
+				F483F431233AC85F00703DE3 /* FBSDKDeviceLoginManagerResult.m in Sources */,
+				F483F432233AC85F00703DE3 /* FBSDKTooltipView.m in Sources */,
+				F483F433233AC85F00703DE3 /* FBSDKDeviceLoginManager.m in Sources */,
+				F483F434233AC85F00703DE3 /* _FBSDKLoginRecoveryAttempter.m in Sources */,
+				F483F435233AC85F00703DE3 /* FBSDKLoginManagerLogger.m in Sources */,
+				F483F436233AC85F00703DE3 /* FBSDKDeviceLoginCodeInfo.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		F487DBDE231EC34B008416A9 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1222,6 +1358,11 @@
 			isa = PBXTargetDependency;
 			target = 9D9DB8D81A114E500086167B /* FBSDKLoginKit */;
 			targetProxy = 9D9DB9631A116AB20086167B /* PBXContainerItemProxy */;
+		};
+		F483F424233AC85F00703DE3 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = FBSDKCoreKitSwift;
+			targetProxy = F483F425233AC85F00703DE3 /* PBXContainerItemProxy */;
 		};
 		F487DC12231EC365008416A9 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -1369,6 +1510,33 @@
 			};
 			name = Release;
 		};
+		F483F44B233AC85F00703DE3 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 81B71EAC1D1A277300933E93 /* FBSDKLoginKit.xcconfig */;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				DEFINES_MODULE = YES;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = mh_dylib;
+				PRODUCT_NAME = FBSDKLoginKit;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		F483F44C233AC85F00703DE3 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 81B71EAC1D1A277300933E93 /* FBSDKLoginKit.xcconfig */;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				DEFINES_MODULE = YES;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = mh_dylib;
+				PRODUCT_NAME = FBSDKLoginKit;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
 		F487DC01231EC34B008416A9 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 81B71EAC1D1A277300933E93 /* FBSDKLoginKit.xcconfig */;
@@ -1465,6 +1633,15 @@
 			buildConfigurations = (
 				9D9DB9611A116A860086167B /* Debug */,
 				9D9DB9621A116A860086167B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		F483F44A233AC85F00703DE3 /* Build configuration list for PBXNativeTarget "FBSDKLoginKitSwift-Dynamic" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F483F44B233AC85F00703DE3 /* Debug */,
+				F483F44C233AC85F00703DE3 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/FBSDKLoginKit/FBSDKLoginKit/Swift/FBSDKLoginKitSwift-Dynamic.xcscheme
+++ b/FBSDKLoginKit/FBSDKLoginKit/Swift/FBSDKLoginKitSwift-Dynamic.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1030"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F483F423233AC85F00703DE3"
+               BuildableName = "FBSDKLoginKit.framework"
+               BlueprintName = "FBSDKLoginKitSwift-Dynamic"
+               ReferencedContainer = "container:FBSDKLoginKit.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F483F423233AC85F00703DE3"
+            BuildableName = "FBSDKLoginKit.framework"
+            BlueprintName = "FBSDKLoginKitSwift-Dynamic"
+            ReferencedContainer = "container:FBSDKLoginKit.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F483F423233AC85F00703DE3"
+            BuildableName = "FBSDKLoginKit.framework"
+            BlueprintName = "FBSDKLoginKitSwift-Dynamic"
+            ReferencedContainer = "container:FBSDKLoginKit.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/FBSDKShareKit/FBSDKShareKit.xcodeproj/project.pbxproj
+++ b/FBSDKShareKit/FBSDKShareKit.xcodeproj/project.pbxproj
@@ -375,6 +375,107 @@
 		EA6CCE941AA7855D00F1EC35 /* FBSDKAppInviteContentTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EA6CCE931AA7855D00F1EC35 /* FBSDKAppInviteContentTests.m */; };
 		EAC370A31AAE3A9C000F0F04 /* FBSDKGameRequestContentTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EAC370A21AAE3A9C000F0F04 /* FBSDKGameRequestContentTests.m */; };
 		F4430BAE2322AF66004C3925 /* Enums+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4430BAD2322AF65004C3925 /* Enums+Extensions.swift */; };
+		F483F45F233AC91700703DE3 /* FBSDKSendButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 890414A41A6EAC0200617215 /* FBSDKSendButton.m */; };
+		F483F460233AC91700703DE3 /* FBSDKLikeBoxView.m in Sources */ = {isa = PBXBuildFile; fileRef = 89688B3A1AA62BD800A98519 /* FBSDKLikeBoxView.m */; };
+		F483F461233AC91700703DE3 /* FBSDKShareMessengerGenericTemplateElement.m in Sources */ = {isa = PBXBuildFile; fileRef = 88A887F11F97E0420075C8BF /* FBSDKShareMessengerGenericTemplateElement.m */; };
+		F483F462233AC91700703DE3 /* FBSDKShareMessengerURLActionButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 883644A71F9555BA00124BCB /* FBSDKShareMessengerURLActionButton.m */; };
+		F483F463233AC91700703DE3 /* FBSDKCameraEffectTextures.m in Sources */ = {isa = PBXBuildFile; fileRef = A4B471ED1E662F74009678AA /* FBSDKCameraEffectTextures.m */; };
+		F483F464233AC91700703DE3 /* FBSDKShareButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 895D8FE41A5F44E9006B16EF /* FBSDKShareButton.m */; };
+		F483F465233AC91700703DE3 /* FBSDKShareVideo.m in Sources */ = {isa = PBXBuildFile; fileRef = 896DE2111A9E280900195731 /* FBSDKShareVideo.m */; };
+		F483F466233AC91700703DE3 /* FBSDKMessageDialog.m in Sources */ = {isa = PBXBuildFile; fileRef = 8904147C1A64843500617215 /* FBSDKMessageDialog.m */; };
+		F483F467233AC91700703DE3 /* FBSDKLikeObjectType.m in Sources */ = {isa = PBXBuildFile; fileRef = 89D05A6F1A9FE02400609300 /* FBSDKLikeObjectType.m */; };
+		F483F468233AC91700703DE3 /* FBSDKShareLinkContent.m in Sources */ = {isa = PBXBuildFile; fileRef = 89CE02E41A3F56470033C9CA /* FBSDKShareLinkContent.m */; };
+		F483F469233AC91700703DE3 /* FBSDKShareExtension.m in Sources */ = {isa = PBXBuildFile; fileRef = B331E2132208C94800F3E4EE /* FBSDKShareExtension.m */; };
+		F483F46A233AC91700703DE3 /* FBSDKShareMessengerMediaTemplateContent.m in Sources */ = {isa = PBXBuildFile; fileRef = 883644B21F95776500124BCB /* FBSDKShareMessengerMediaTemplateContent.m */; };
+		F483F46B233AC91700703DE3 /* FBSDKSharePhotoContent.m in Sources */ = {isa = PBXBuildFile; fileRef = 89FC9C6E1A3FA1E00001910E /* FBSDKSharePhotoContent.m */; };
+		F483F46C233AC91700703DE3 /* FBSDKShareMessengerGenericTemplateContent.m in Sources */ = {isa = PBXBuildFile; fileRef = 88A887E41F97DD7F0075C8BF /* FBSDKShareMessengerGenericTemplateContent.m */; };
+		F483F46D233AC91700703DE3 /* Enums+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4430BAD2322AF65004C3925 /* Enums+Extensions.swift */; };
+		F483F46E233AC91700703DE3 /* FBSDKShareDialog.m in Sources */ = {isa = PBXBuildFile; fileRef = 8973B3781A40A8B90001EDC5 /* FBSDKShareDialog.m */; };
+		F483F46F233AC91700703DE3 /* FBSDKLikeDialog.m in Sources */ = {isa = PBXBuildFile; fileRef = 89D05A771A9FE4CB00609300 /* FBSDKLikeDialog.m */; };
+		F483F470233AC91700703DE3 /* FBSDKCheckmarkIcon.m in Sources */ = {isa = PBXBuildFile; fileRef = 891687E11AB35E8400F55364 /* FBSDKCheckmarkIcon.m */; };
+		F483F471233AC91700703DE3 /* FBSDKGameRequestContent.m in Sources */ = {isa = PBXBuildFile; fileRef = 89F2037F1AA922DB0053499E /* FBSDKGameRequestContent.m */; };
+		F483F472233AC91700703DE3 /* FBSDKShareOpenGraphValueContainer.m in Sources */ = {isa = PBXBuildFile; fileRef = 89C1DCB11A4351F700F0F9B2 /* FBSDKShareOpenGraphValueContainer.m */; };
+		F483F473233AC91700703DE3 /* FBSDKLikeActionControllerCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 89CE85E41AA4D1940030C6FA /* FBSDKLikeActionControllerCache.m */; };
+		F483F474233AC91700703DE3 /* FBSDKShareCameraEffectContent.m in Sources */ = {isa = PBXBuildFile; fileRef = A49C0EFE1E54E6E400157726 /* FBSDKShareCameraEffectContent.m */; };
+		F483F475233AC91700703DE3 /* FBSDKGameRequestDialog.m in Sources */ = {isa = PBXBuildFile; fileRef = 89F203831AA9255B0053499E /* FBSDKGameRequestDialog.m */; };
+		F483F476233AC91700703DE3 /* FBSDKShareConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 893774881A3B5B9A00BE2807 /* FBSDKShareConstants.m */; };
+		F483F477233AC91700703DE3 /* FBSDKMessengerIcon.m in Sources */ = {isa = PBXBuildFile; fileRef = 891687E51AB35F2D00F55364 /* FBSDKMessengerIcon.m */; };
+		F483F478233AC91700703DE3 /* FBSDKShareUtility.m in Sources */ = {isa = PBXBuildFile; fileRef = 891C54571A3BB23F00DF05AF /* FBSDKShareUtility.m */; };
+		F483F479233AC91700703DE3 /* FBSDKShareOpenGraphAction.m in Sources */ = {isa = PBXBuildFile; fileRef = 8937748C1A3B5E9E00BE2807 /* FBSDKShareOpenGraphAction.m */; };
+		F483F47A233AC91700703DE3 /* FBSDKCameraEffectArguments.m in Sources */ = {isa = PBXBuildFile; fileRef = A49C0F0E1E55098400157726 /* FBSDKCameraEffectArguments.m */; };
+		F483F47B233AC91700703DE3 /* FBSDKShareVideoContent.m in Sources */ = {isa = PBXBuildFile; fileRef = 896DE2191A9E282800195731 /* FBSDKShareVideoContent.m */; };
+		F483F47C233AC91700703DE3 /* FBSDKShareAPI.m in Sources */ = {isa = PBXBuildFile; fileRef = 89DC6CC71A81792000814152 /* FBSDKShareAPI.m */; };
+		F483F47D233AC91700703DE3 /* FBSDKShareMessengerOpenGraphMusicTemplateContent.m in Sources */ = {isa = PBXBuildFile; fileRef = 8846907A1F9968240042CF48 /* FBSDKShareMessengerOpenGraphMusicTemplateContent.m */; };
+		F483F47E233AC91700703DE3 /* FBSDKVideoUploader.m in Sources */ = {isa = PBXBuildFile; fileRef = 9382B78F1BB3A5AD00E4B24F /* FBSDKVideoUploader.m */; };
+		F483F47F233AC91700703DE3 /* FBSDKShareDialogMode.m in Sources */ = {isa = PBXBuildFile; fileRef = DB38B6821AAF668100099656 /* FBSDKShareDialogMode.m */; };
+		F483F480233AC91700703DE3 /* FBSDKLikeActionController.m in Sources */ = {isa = PBXBuildFile; fileRef = 89D05A7E1AA0E0D300609300 /* FBSDKLikeActionController.m */; };
+		F483F481233AC91700703DE3 /* FBSDKShareMediaContent.m in Sources */ = {isa = PBXBuildFile; fileRef = 03A419D91C922A2A006E7767 /* FBSDKShareMediaContent.m */; };
+		F483F482233AC91700703DE3 /* FBSDKLikeBoxBorderView.m in Sources */ = {isa = PBXBuildFile; fileRef = 89688B411AA62C4100A98519 /* FBSDKLikeBoxBorderView.m */; };
+		F483F483233AC91700703DE3 /* FBSDKShareOpenGraphObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 893774761A3A585600BE2807 /* FBSDKShareOpenGraphObject.m */; };
+		F483F484233AC91700703DE3 /* FBSDKShareMessengerContentUtility.m in Sources */ = {isa = PBXBuildFile; fileRef = 886F746D1F9EA38400BD9AC3 /* FBSDKShareMessengerContentUtility.m */; };
+		F483F485233AC91700703DE3 /* FBSDKSharePhoto.m in Sources */ = {isa = PBXBuildFile; fileRef = 892EBBF51A3A50D700721B03 /* FBSDKSharePhoto.m */; };
+		F483F486233AC91700703DE3 /* FBSDKAppGroupContent.m in Sources */ = {isa = PBXBuildFile; fileRef = 89F203AE1AAA45BA0053499E /* FBSDKAppGroupContent.m */; };
+		F483F487233AC91700703DE3 /* FBSDKGameRequestFrictionlessRecipientCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 89F203A01AAA0DF80053499E /* FBSDKGameRequestFrictionlessRecipientCache.m */; };
+		F483F488233AC91700703DE3 /* FBSDKShareOpenGraphContent.m in Sources */ = {isa = PBXBuildFile; fileRef = 898D17E01A407F2F005E32C7 /* FBSDKShareOpenGraphContent.m */; };
+		F483F489233AC91700703DE3 /* FBSDKHashtag.m in Sources */ = {isa = PBXBuildFile; fileRef = D5158B5B1C5FD492003E32EE /* FBSDKHashtag.m */; };
+		F483F48A233AC91700703DE3 /* FBSDKAppInviteContent.m in Sources */ = {isa = PBXBuildFile; fileRef = EA3D469E1AA6835900D0C7D5 /* FBSDKAppInviteContent.m */; };
+		F483F48D233AC91700703DE3 /* FBSDKShareMessengerMediaTemplateContent.h in Headers */ = {isa = PBXBuildFile; fileRef = 883644B11F95776500124BCB /* FBSDKShareMessengerMediaTemplateContent.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F48E233AC91700703DE3 /* FBSDKAppInviteContent.h in Headers */ = {isa = PBXBuildFile; fileRef = EA3D469C1AA66C5F00D0C7D5 /* FBSDKAppInviteContent.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F48F233AC91700703DE3 /* FBSDKShareOpenGraphAction.h in Headers */ = {isa = PBXBuildFile; fileRef = 8937748B1A3B5E9E00BE2807 /* FBSDKShareOpenGraphAction.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F490233AC91700703DE3 /* FBSDKShareMessengerURLActionButton.h in Headers */ = {isa = PBXBuildFile; fileRef = 883644A61F9555BA00124BCB /* FBSDKShareMessengerURLActionButton.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F491233AC91700703DE3 /* FBSDKShareDialog.h in Headers */ = {isa = PBXBuildFile; fileRef = 8973B3771A40A8B90001EDC5 /* FBSDKShareDialog.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F492233AC91700703DE3 /* FBSDKShareVideoContent.h in Headers */ = {isa = PBXBuildFile; fileRef = 896DE2181A9E282800195731 /* FBSDKShareVideoContent.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F493233AC91700703DE3 /* FBSDKShareVideo.h in Headers */ = {isa = PBXBuildFile; fileRef = 896DE2101A9E280900195731 /* FBSDKShareVideo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F494233AC91700703DE3 /* FBSDKCoreKit+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 890414751A647DB200617215 /* FBSDKCoreKit+Internal.h */; };
+		F483F495233AC91700703DE3 /* FBSDKLiking.h in Headers */ = {isa = PBXBuildFile; fileRef = 89688B551AA639CB00A98519 /* FBSDKLiking.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F496233AC91700703DE3 /* FBSDKShareDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = 8904148A1A648DAC00617215 /* FBSDKShareDefines.h */; };
+		F483F497233AC91700703DE3 /* FBSDKGameRequestDialog.h in Headers */ = {isa = PBXBuildFile; fileRef = 89F203821AA9255B0053499E /* FBSDKGameRequestDialog.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F498233AC91700703DE3 /* FBSDKLikeObjectType.h in Headers */ = {isa = PBXBuildFile; fileRef = 89D05A6E1A9FE02400609300 /* FBSDKLikeObjectType.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F499233AC91700703DE3 /* FBSDKShareConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = 893774871A3B5B9A00BE2807 /* FBSDKShareConstants.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F49A233AC91700703DE3 /* FBSDKSharingContent.h in Headers */ = {isa = PBXBuildFile; fileRef = 8973B37B1A40A93D0001EDC5 /* FBSDKSharingContent.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F49B233AC91700703DE3 /* FBSDKLikeButton+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 89688B261AA529D900A98519 /* FBSDKLikeButton+Internal.h */; };
+		F483F49C233AC91700703DE3 /* FBSDKShareMessengerOpenGraphMusicTemplateContent.h in Headers */ = {isa = PBXBuildFile; fileRef = 884690791F9968240042CF48 /* FBSDKShareMessengerOpenGraphMusicTemplateContent.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F49D233AC91700703DE3 /* FBSDKCameraEffectTextures.h in Headers */ = {isa = PBXBuildFile; fileRef = A4B471EC1E662F74009678AA /* FBSDKCameraEffectTextures.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F49E233AC91700703DE3 /* FBSDKCameraEffectArguments.h in Headers */ = {isa = PBXBuildFile; fileRef = A49C0F0D1E55098400157726 /* FBSDKCameraEffectArguments.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F49F233AC91700703DE3 /* FBSDKAppGroupContent.h in Headers */ = {isa = PBXBuildFile; fileRef = 89F203AD1AAA45BA0053499E /* FBSDKAppGroupContent.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F4A0233AC91700703DE3 /* FBSDKLikeBoxView.h in Headers */ = {isa = PBXBuildFile; fileRef = 89688B391AA62BD800A98519 /* FBSDKLikeBoxView.h */; };
+		F483F4A1233AC91700703DE3 /* FBSDKShareUtility.h in Headers */ = {isa = PBXBuildFile; fileRef = 891C54561A3BB23F00DF05AF /* FBSDKShareUtility.h */; };
+		F483F4A2233AC91700703DE3 /* FBSDKMessageDialog.h in Headers */ = {isa = PBXBuildFile; fileRef = 8904147B1A64843500617215 /* FBSDKMessageDialog.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F4A3233AC91700703DE3 /* FBSDKVideoUploader.h in Headers */ = {isa = PBXBuildFile; fileRef = 9382B78D1BB3A54000E4B24F /* FBSDKVideoUploader.h */; };
+		F483F4A4233AC91700703DE3 /* FBSDKShareLinkContent.h in Headers */ = {isa = PBXBuildFile; fileRef = 89CE02E31A3F56470033C9CA /* FBSDKShareLinkContent.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F4A5233AC91700703DE3 /* FBSDKShareOpenGraphObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 893774751A3A585600BE2807 /* FBSDKShareOpenGraphObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F4A6233AC91700703DE3 /* FBSDKSharingScheme.h in Headers */ = {isa = PBXBuildFile; fileRef = B38A44B920BC71E800DDE80D /* FBSDKSharingScheme.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F4A7233AC91700703DE3 /* FBSDKShareCameraEffectContent.h in Headers */ = {isa = PBXBuildFile; fileRef = A49C0EFD1E54E6E400157726 /* FBSDKShareCameraEffectContent.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F4A8233AC91700703DE3 /* FBSDKLikeBoxBorderView.h in Headers */ = {isa = PBXBuildFile; fileRef = 89688B401AA62C4100A98519 /* FBSDKLikeBoxBorderView.h */; };
+		F483F4A9233AC91700703DE3 /* FBSDKLikeActionControllerCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 89CE85E31AA4D1940030C6FA /* FBSDKLikeActionControllerCache.h */; };
+		F483F4AA233AC91700703DE3 /* FBSDKCameraEffectTextures+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = A41549F61E6653AE001F7152 /* FBSDKCameraEffectTextures+Internal.h */; };
+		F483F4AB233AC91700703DE3 /* FBSDKSharing.h in Headers */ = {isa = PBXBuildFile; fileRef = 8904147F1A64849100617215 /* FBSDKSharing.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F4AC233AC91700703DE3 /* FBSDKLikeActionController.h in Headers */ = {isa = PBXBuildFile; fileRef = 89D05A7D1AA0E0D300609300 /* FBSDKLikeActionController.h */; };
+		F483F4AD233AC91700703DE3 /* FBSDKShareMessengerGenericTemplateContent.h in Headers */ = {isa = PBXBuildFile; fileRef = 88A887E31F97DD7F0075C8BF /* FBSDKShareMessengerGenericTemplateContent.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F4AE233AC91700703DE3 /* FBSDKSharePhoto.h in Headers */ = {isa = PBXBuildFile; fileRef = 892EBBF41A3A50D700721B03 /* FBSDKSharePhoto.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F4AF233AC91700703DE3 /* FBSDKShareMediaContent.h in Headers */ = {isa = PBXBuildFile; fileRef = 03A419D81C922A2A006E7767 /* FBSDKShareMediaContent.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F4B0233AC91700703DE3 /* FBSDKSendButton.h in Headers */ = {isa = PBXBuildFile; fileRef = 890414A31A6EAC0200617215 /* FBSDKSendButton.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F4B1233AC91700703DE3 /* FBSDKShareMessengerGenericTemplateElement.h in Headers */ = {isa = PBXBuildFile; fileRef = 88A887F01F97E0420075C8BF /* FBSDKShareMessengerGenericTemplateElement.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F4B2233AC91700703DE3 /* FBSDKSharingValidation.h in Headers */ = {isa = PBXBuildFile; fileRef = B37494B320BA52E600CF7DC1 /* FBSDKSharingValidation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F4B3233AC91700703DE3 /* FBSDKShareDialogMode.h in Headers */ = {isa = PBXBuildFile; fileRef = DB38B6811AAF663600099656 /* FBSDKShareDialogMode.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F4B4233AC91700703DE3 /* FBSDKMessengerIcon.h in Headers */ = {isa = PBXBuildFile; fileRef = 891687E41AB35F2D00F55364 /* FBSDKMessengerIcon.h */; };
+		F483F4B5233AC91700703DE3 /* FBSDKSharingButton.h in Headers */ = {isa = PBXBuildFile; fileRef = 890414A71A6EB7F900617215 /* FBSDKSharingButton.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F4B6233AC91700703DE3 /* FBSDKShareKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D46C5F51A11E5D800A0DDB6 /* FBSDKShareKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F4B7233AC91700703DE3 /* FBSDKShareOpenGraphValueContainer+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 89C1DCB41A43528900F0F9B2 /* FBSDKShareOpenGraphValueContainer+Internal.h */; };
+		F483F4B8233AC91700703DE3 /* FBSDKGameRequestFrictionlessRecipientCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 89F2039F1AAA0DF80053499E /* FBSDKGameRequestFrictionlessRecipientCache.h */; };
+		F483F4B9233AC91700703DE3 /* FBSDKHashtag.h in Headers */ = {isa = PBXBuildFile; fileRef = D5158B5A1C5FD492003E32EE /* FBSDKHashtag.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F4BA233AC91700703DE3 /* FBSDKSharePhotoContent.h in Headers */ = {isa = PBXBuildFile; fileRef = 89FC9C6D1A3FA1E00001910E /* FBSDKSharePhotoContent.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F4BB233AC91700703DE3 /* FBSDKShareExtension.h in Headers */ = {isa = PBXBuildFile; fileRef = B331E2172208C94800F3E4EE /* FBSDKShareExtension.h */; };
+		F483F4BC233AC91700703DE3 /* FBSDKCheckmarkIcon.h in Headers */ = {isa = PBXBuildFile; fileRef = 891687E01AB35E8400F55364 /* FBSDKCheckmarkIcon.h */; };
+		F483F4BD233AC91700703DE3 /* FBSDKShareMessengerActionButton.h in Headers */ = {isa = PBXBuildFile; fileRef = 8836449B1F9551B000124BCB /* FBSDKShareMessengerActionButton.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F4BE233AC91700703DE3 /* FBSDKCameraEffectArguments+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = A4F33E731E677A8600747AFD /* FBSDKCameraEffectArguments+Internal.h */; };
+		F483F4BF233AC91700703DE3 /* FBSDKShareOpenGraphContent.h in Headers */ = {isa = PBXBuildFile; fileRef = 898D17DF1A407F2F005E32C7 /* FBSDKShareOpenGraphContent.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F4C0233AC91700703DE3 /* FBSDKShareButton.h in Headers */ = {isa = PBXBuildFile; fileRef = 895D8FE31A5F44E9006B16EF /* FBSDKShareButton.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F4C1233AC91700703DE3 /* FBSDKShareMessengerContentUtility.h in Headers */ = {isa = PBXBuildFile; fileRef = 886F746C1F9EA38400BD9AC3 /* FBSDKShareMessengerContentUtility.h */; };
+		F483F4C2233AC91700703DE3 /* FBSDKShareOpenGraphValueContainer.h in Headers */ = {isa = PBXBuildFile; fileRef = 89C1DCB01A4351F700F0F9B2 /* FBSDKShareOpenGraphValueContainer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F4C3233AC91700703DE3 /* FBSDKShareAPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 89DC6CC61A81792000814152 /* FBSDKShareAPI.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F483F4C4233AC91700703DE3 /* FBSDKLikeDialog.h in Headers */ = {isa = PBXBuildFile; fileRef = 89D05A761A9FE4CB00609300 /* FBSDKLikeDialog.h */; };
+		F483F4C5233AC91700703DE3 /* FBSDKGameRequestContent.h in Headers */ = {isa = PBXBuildFile; fileRef = 89F2037E1AA922DB0053499E /* FBSDKGameRequestContent.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F487DC1C231EC4CC008416A9 /* FBSDKSendButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 890414A41A6EAC0200617215 /* FBSDKSendButton.m */; };
 		F487DC1D231EC4CC008416A9 /* FBSDKLikeBoxView.m in Sources */ = {isa = PBXBuildFile; fileRef = 89688B3A1AA62BD800A98519 /* FBSDKLikeBoxView.m */; };
 		F487DC1E231EC4CC008416A9 /* FBSDKShareMessengerGenericTemplateElement.m in Sources */ = {isa = PBXBuildFile; fileRef = 88A887F11F97E0420075C8BF /* FBSDKShareMessengerGenericTemplateElement.m */; };
@@ -597,6 +698,20 @@
 			remoteGlobalIDString = C5C4B4EA2276BA8D00CA3706;
 			remoteInfo = "FBSDKCoreKit_Basics_TV-Dynamic";
 		};
+		F483F45D233AC91700703DE3 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8118B6341D0A49B500962084 /* FBSDKCoreKit.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = F487DADD231EBCD2008416A9;
+			remoteInfo = FBSDKCoreKitSwift;
+		};
+		F483F4D5233AC91700703DE3 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8118B6341D0A49B500962084 /* FBSDKCoreKit.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = F483F414233AC13000703DE3;
+			remoteInfo = "FBSDKCoreKitSwift-Dynamic";
+		};
 		F487DC92231EC4CC008416A9 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 8118B6341D0A49B500962084 /* FBSDKCoreKit.xcodeproj */;
@@ -785,6 +900,7 @@
 		EA6CCE931AA7855D00F1EC35 /* FBSDKAppInviteContentTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSDKAppInviteContentTests.m; sourceTree = "<group>"; };
 		EAC370A21AAE3A9C000F0F04 /* FBSDKGameRequestContentTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSDKGameRequestContentTests.m; sourceTree = "<group>"; };
 		F4430BAD2322AF65004C3925 /* Enums+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Enums+Extensions.swift"; path = "Swift/Enums+Extensions.swift"; sourceTree = "<group>"; };
+		F483F4CA233AC91700703DE3 /* FBSDKShareKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FBSDKShareKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F487DC86231EC4CC008416A9 /* FBSDKShareKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FBSDKShareKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -838,6 +954,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		F483F48B233AC91700703DE3 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		F487DC47231EC4CC008416A9 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -861,6 +984,7 @@
 				C57538C92292B6D5007C2EFF /* FBSDKCoreKit.framework */,
 				C57538CB2292B6D5007C2EFF /* FBSDKCoreKit.framework */,
 				F487DC93231EC4CC008416A9 /* FBSDKCoreKit.framework */,
+				F483F4D6233AC91700703DE3 /* FBSDKCoreKit.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1106,6 +1230,7 @@
 				81A07F441D1A2E6A0041A29C /* FBSDKShareKit.framework */,
 				8144D91B1D261D2900C8E4AC /* FBSDKShareKit.framework */,
 				F487DC86231EC4CC008416A9 /* FBSDKShareKit.framework */,
+				F483F4CA233AC91700703DE3 /* FBSDKShareKit.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1386,6 +1511,70 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		F483F48C233AC91700703DE3 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F483F48D233AC91700703DE3 /* FBSDKShareMessengerMediaTemplateContent.h in Headers */,
+				F483F48E233AC91700703DE3 /* FBSDKAppInviteContent.h in Headers */,
+				F483F48F233AC91700703DE3 /* FBSDKShareOpenGraphAction.h in Headers */,
+				F483F490233AC91700703DE3 /* FBSDKShareMessengerURLActionButton.h in Headers */,
+				F483F491233AC91700703DE3 /* FBSDKShareDialog.h in Headers */,
+				F483F492233AC91700703DE3 /* FBSDKShareVideoContent.h in Headers */,
+				F483F493233AC91700703DE3 /* FBSDKShareVideo.h in Headers */,
+				F483F494233AC91700703DE3 /* FBSDKCoreKit+Internal.h in Headers */,
+				F483F495233AC91700703DE3 /* FBSDKLiking.h in Headers */,
+				F483F496233AC91700703DE3 /* FBSDKShareDefines.h in Headers */,
+				F483F497233AC91700703DE3 /* FBSDKGameRequestDialog.h in Headers */,
+				F483F498233AC91700703DE3 /* FBSDKLikeObjectType.h in Headers */,
+				F483F499233AC91700703DE3 /* FBSDKShareConstants.h in Headers */,
+				F483F49A233AC91700703DE3 /* FBSDKSharingContent.h in Headers */,
+				F483F49B233AC91700703DE3 /* FBSDKLikeButton+Internal.h in Headers */,
+				F483F49C233AC91700703DE3 /* FBSDKShareMessengerOpenGraphMusicTemplateContent.h in Headers */,
+				F483F49D233AC91700703DE3 /* FBSDKCameraEffectTextures.h in Headers */,
+				F483F49E233AC91700703DE3 /* FBSDKCameraEffectArguments.h in Headers */,
+				F483F49F233AC91700703DE3 /* FBSDKAppGroupContent.h in Headers */,
+				F483F4A0233AC91700703DE3 /* FBSDKLikeBoxView.h in Headers */,
+				F483F4A1233AC91700703DE3 /* FBSDKShareUtility.h in Headers */,
+				F483F4A2233AC91700703DE3 /* FBSDKMessageDialog.h in Headers */,
+				F483F4A3233AC91700703DE3 /* FBSDKVideoUploader.h in Headers */,
+				F483F4A4233AC91700703DE3 /* FBSDKShareLinkContent.h in Headers */,
+				F483F4A5233AC91700703DE3 /* FBSDKShareOpenGraphObject.h in Headers */,
+				F483F4A6233AC91700703DE3 /* FBSDKSharingScheme.h in Headers */,
+				F483F4A7233AC91700703DE3 /* FBSDKShareCameraEffectContent.h in Headers */,
+				F483F4A8233AC91700703DE3 /* FBSDKLikeBoxBorderView.h in Headers */,
+				F483F4A9233AC91700703DE3 /* FBSDKLikeActionControllerCache.h in Headers */,
+				F483F4AA233AC91700703DE3 /* FBSDKCameraEffectTextures+Internal.h in Headers */,
+				F483F4AB233AC91700703DE3 /* FBSDKSharing.h in Headers */,
+				F483F4AC233AC91700703DE3 /* FBSDKLikeActionController.h in Headers */,
+				F483F4AD233AC91700703DE3 /* FBSDKShareMessengerGenericTemplateContent.h in Headers */,
+				F483F4AE233AC91700703DE3 /* FBSDKSharePhoto.h in Headers */,
+				F483F4AF233AC91700703DE3 /* FBSDKShareMediaContent.h in Headers */,
+				F483F4B0233AC91700703DE3 /* FBSDKSendButton.h in Headers */,
+				F483F4B1233AC91700703DE3 /* FBSDKShareMessengerGenericTemplateElement.h in Headers */,
+				F483F4B2233AC91700703DE3 /* FBSDKSharingValidation.h in Headers */,
+				F483F4B3233AC91700703DE3 /* FBSDKShareDialogMode.h in Headers */,
+				F483F4B4233AC91700703DE3 /* FBSDKMessengerIcon.h in Headers */,
+				F483F4B5233AC91700703DE3 /* FBSDKSharingButton.h in Headers */,
+				F483F4B6233AC91700703DE3 /* FBSDKShareKit.h in Headers */,
+				F483F4B7233AC91700703DE3 /* FBSDKShareOpenGraphValueContainer+Internal.h in Headers */,
+				F483F4B8233AC91700703DE3 /* FBSDKGameRequestFrictionlessRecipientCache.h in Headers */,
+				F483F4B9233AC91700703DE3 /* FBSDKHashtag.h in Headers */,
+				F483F4BA233AC91700703DE3 /* FBSDKSharePhotoContent.h in Headers */,
+				F483F4BB233AC91700703DE3 /* FBSDKShareExtension.h in Headers */,
+				F483F4BC233AC91700703DE3 /* FBSDKCheckmarkIcon.h in Headers */,
+				F483F4BD233AC91700703DE3 /* FBSDKShareMessengerActionButton.h in Headers */,
+				F483F4BE233AC91700703DE3 /* FBSDKCameraEffectArguments+Internal.h in Headers */,
+				F483F4BF233AC91700703DE3 /* FBSDKShareOpenGraphContent.h in Headers */,
+				F483F4C0233AC91700703DE3 /* FBSDKShareButton.h in Headers */,
+				F483F4C1233AC91700703DE3 /* FBSDKShareMessengerContentUtility.h in Headers */,
+				F483F4C2233AC91700703DE3 /* FBSDKShareOpenGraphValueContainer.h in Headers */,
+				F483F4C3233AC91700703DE3 /* FBSDKShareAPI.h in Headers */,
+				F483F4C4233AC91700703DE3 /* FBSDKLikeDialog.h in Headers */,
+				F483F4C5233AC91700703DE3 /* FBSDKGameRequestContent.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		F487DC48231EC4CC008416A9 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -1549,6 +1738,25 @@
 			productReference = 9D46C5FB1A11E5D800A0DDB6 /* FBSDKShareKitTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		F483F45B233AC91700703DE3 /* FBSDKShareKitSwift-Dynamic */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F483F4C7233AC91700703DE3 /* Build configuration list for PBXNativeTarget "FBSDKShareKitSwift-Dynamic" */;
+			buildPhases = (
+				F483F45E233AC91700703DE3 /* Sources */,
+				F483F48B233AC91700703DE3 /* Frameworks */,
+				F483F48C233AC91700703DE3 /* Headers */,
+				F483F4C6233AC91700703DE3 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				F483F45C233AC91700703DE3 /* PBXTargetDependency */,
+			);
+			name = "FBSDKShareKitSwift-Dynamic";
+			productName = FBSDKShareKit;
+			productReference = F483F4CA233AC91700703DE3 /* FBSDKShareKit.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 		F487DC18231EC4CC008416A9 /* FBSDKShareKitSwift */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = F487DC83231EC4CC008416A9 /* Build configuration list for PBXNativeTarget "FBSDKShareKitSwift" */;
@@ -1624,6 +1832,7 @@
 				8144D8E81D261D2900C8E4AC /* FBSDKShareKit_TV-Dynamic */,
 				9D2D99BE1BC456B200929E76 /* FBSDKShareKit_TV-Universal */,
 				F487DC18231EC4CC008416A9 /* FBSDKShareKitSwift */,
+				F483F45B233AC91700703DE3 /* FBSDKShareKitSwift-Dynamic */,
 			);
 		};
 /* End PBXProject section */
@@ -1692,6 +1901,13 @@
 			remoteRef = C57538CA2292B6D5007C2EFF /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
+		F483F4D6233AC91700703DE3 /* FBSDKCoreKit.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = FBSDKCoreKit.framework;
+			remoteRef = F483F4D5233AC91700703DE3 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
 		F487DC93231EC4CC008416A9 /* FBSDKCoreKit.framework */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.framework;
@@ -1736,6 +1952,13 @@
 			files = (
 				D530CB671D51253100D803D6 /* test-image.jpeg in Resources */,
 				D55660171D91FF6600046113 /* bicycle.png in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F483F4C6233AC91700703DE3 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1964,6 +2187,57 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		F483F45E233AC91700703DE3 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F483F45F233AC91700703DE3 /* FBSDKSendButton.m in Sources */,
+				F483F460233AC91700703DE3 /* FBSDKLikeBoxView.m in Sources */,
+				F483F461233AC91700703DE3 /* FBSDKShareMessengerGenericTemplateElement.m in Sources */,
+				F483F462233AC91700703DE3 /* FBSDKShareMessengerURLActionButton.m in Sources */,
+				F483F463233AC91700703DE3 /* FBSDKCameraEffectTextures.m in Sources */,
+				F483F464233AC91700703DE3 /* FBSDKShareButton.m in Sources */,
+				F483F465233AC91700703DE3 /* FBSDKShareVideo.m in Sources */,
+				F483F466233AC91700703DE3 /* FBSDKMessageDialog.m in Sources */,
+				F483F467233AC91700703DE3 /* FBSDKLikeObjectType.m in Sources */,
+				F483F468233AC91700703DE3 /* FBSDKShareLinkContent.m in Sources */,
+				F483F469233AC91700703DE3 /* FBSDKShareExtension.m in Sources */,
+				F483F46A233AC91700703DE3 /* FBSDKShareMessengerMediaTemplateContent.m in Sources */,
+				F483F46B233AC91700703DE3 /* FBSDKSharePhotoContent.m in Sources */,
+				F483F46C233AC91700703DE3 /* FBSDKShareMessengerGenericTemplateContent.m in Sources */,
+				F483F46D233AC91700703DE3 /* Enums+Extensions.swift in Sources */,
+				F483F46E233AC91700703DE3 /* FBSDKShareDialog.m in Sources */,
+				F483F46F233AC91700703DE3 /* FBSDKLikeDialog.m in Sources */,
+				F483F470233AC91700703DE3 /* FBSDKCheckmarkIcon.m in Sources */,
+				F483F471233AC91700703DE3 /* FBSDKGameRequestContent.m in Sources */,
+				F483F472233AC91700703DE3 /* FBSDKShareOpenGraphValueContainer.m in Sources */,
+				F483F473233AC91700703DE3 /* FBSDKLikeActionControllerCache.m in Sources */,
+				F483F474233AC91700703DE3 /* FBSDKShareCameraEffectContent.m in Sources */,
+				F483F475233AC91700703DE3 /* FBSDKGameRequestDialog.m in Sources */,
+				F483F476233AC91700703DE3 /* FBSDKShareConstants.m in Sources */,
+				F483F477233AC91700703DE3 /* FBSDKMessengerIcon.m in Sources */,
+				F483F478233AC91700703DE3 /* FBSDKShareUtility.m in Sources */,
+				F483F479233AC91700703DE3 /* FBSDKShareOpenGraphAction.m in Sources */,
+				F483F47A233AC91700703DE3 /* FBSDKCameraEffectArguments.m in Sources */,
+				F483F47B233AC91700703DE3 /* FBSDKShareVideoContent.m in Sources */,
+				F483F47C233AC91700703DE3 /* FBSDKShareAPI.m in Sources */,
+				F483F47D233AC91700703DE3 /* FBSDKShareMessengerOpenGraphMusicTemplateContent.m in Sources */,
+				F483F47E233AC91700703DE3 /* FBSDKVideoUploader.m in Sources */,
+				F483F47F233AC91700703DE3 /* FBSDKShareDialogMode.m in Sources */,
+				F483F480233AC91700703DE3 /* FBSDKLikeActionController.m in Sources */,
+				F483F481233AC91700703DE3 /* FBSDKShareMediaContent.m in Sources */,
+				F483F482233AC91700703DE3 /* FBSDKLikeBoxBorderView.m in Sources */,
+				F483F483233AC91700703DE3 /* FBSDKShareOpenGraphObject.m in Sources */,
+				F483F484233AC91700703DE3 /* FBSDKShareMessengerContentUtility.m in Sources */,
+				F483F485233AC91700703DE3 /* FBSDKSharePhoto.m in Sources */,
+				F483F486233AC91700703DE3 /* FBSDKAppGroupContent.m in Sources */,
+				F483F487233AC91700703DE3 /* FBSDKGameRequestFrictionlessRecipientCache.m in Sources */,
+				F483F488233AC91700703DE3 /* FBSDKShareOpenGraphContent.m in Sources */,
+				F483F489233AC91700703DE3 /* FBSDKHashtag.m in Sources */,
+				F483F48A233AC91700703DE3 /* FBSDKAppInviteContent.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		F487DC1B231EC4CC008416A9 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -2061,6 +2335,11 @@
 			isa = PBXTargetDependency;
 			target = 9D46C5EF1A11E5D800A0DDB6 /* FBSDKShareKit */;
 			targetProxy = 9D46C6151A11E6F100A0DDB6 /* PBXContainerItemProxy */;
+		};
+		F483F45C233AC91700703DE3 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = FBSDKCoreKitSwift;
+			targetProxy = F483F45D233AC91700703DE3 /* PBXContainerItemProxy */;
 		};
 		F487DC95231EC50C008416A9 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -2204,6 +2483,33 @@
 			};
 			name = Release;
 		};
+		F483F4C8233AC91700703DE3 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 819043CE1D261A7900B2E437 /* FBSDKShareKit.xcconfig */;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				DEFINES_MODULE = YES;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = mh_dylib;
+				PRODUCT_NAME = FBSDKShareKit;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		F483F4C9233AC91700703DE3 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 819043CE1D261A7900B2E437 /* FBSDKShareKit.xcconfig */;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				DEFINES_MODULE = YES;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = mh_dylib;
+				PRODUCT_NAME = FBSDKShareKit;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
 		F487DC84231EC4CC008416A9 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 819043CE1D261A7900B2E437 /* FBSDKShareKit.xcconfig */;
@@ -2300,6 +2606,15 @@
 			buildConfigurations = (
 				9D46C6121A11E6D800A0DDB6 /* Debug */,
 				9D46C6131A11E6D800A0DDB6 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		F483F4C7233AC91700703DE3 /* Build configuration list for PBXNativeTarget "FBSDKShareKitSwift-Dynamic" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F483F4C8233AC91700703DE3 /* Debug */,
+				F483F4C9233AC91700703DE3 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/FBSDKShareKit/FBSDKShareKit/Swift/FBSDKShareKitSwift-Dynamic.xcscheme
+++ b/FBSDKShareKit/FBSDKShareKit/Swift/FBSDKShareKitSwift-Dynamic.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1030"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F483F45B233AC91700703DE3"
+               BuildableName = "FBSDKShareKit.framework"
+               BlueprintName = "FBSDKShareKitSwift-Dynamic"
+               ReferencedContainer = "container:FBSDKShareKit.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F483F45B233AC91700703DE3"
+            BuildableName = "FBSDKShareKit.framework"
+            BlueprintName = "FBSDKShareKitSwift-Dynamic"
+            ReferencedContainer = "container:FBSDKShareKit.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F483F45B233AC91700703DE3"
+            BuildableName = "FBSDKShareKit.framework"
+            BlueprintName = "FBSDKShareKitSwift-Dynamic"
+            ReferencedContainer = "container:FBSDKShareKit.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/scripts/combineReleases.rb
+++ b/scripts/combineReleases.rb
@@ -1,0 +1,75 @@
+#!/usr/bin/env ruby
+
+require 'json'
+require "net/http"
+require 'open-uri'
+require 'zip'
+
+require 'byebug'
+
+class GitHubConstants
+  Name = 'name'
+  DownloadURL = 'browser_download_url'
+  ReleaseURL = 'https://api.github.com/repos/facebook/facebook-objc-sdk/releases/latest'
+end
+
+class Filenames
+  DynamicFrameworks = 'FacebookSDK_Dynamic.framework.zip'
+  SwiftDynamicFrameworks = 'Swift.zip'
+
+  ObjcDynamicFrameworksZip = 'objcDynamicFrameworks.zip'
+  SwiftDynamicFrameworksZip = 'swiftDynamicFrameworks.zip'
+end
+
+# Fetch the latest release from github
+url = GitHubConstants::ReleaseURL
+uri = URI(url)
+response = Net::HTTP.get(uri)
+
+json = JSON.parse(response)
+assets = json['assets']
+
+# Get the asset with the name FacebookSDK_Dynamic.framework.zip
+objcDynamicFrameworksAsset = assets.find{ |asset|
+  asset[GitHubConstants::Name] == Filenames::DynamicFrameworks
+}
+objcDynamicFrameworksURL = objcDynamicFrameworksAsset[GitHubConstants::DownloadURL]
+objcDynamicFrameworksZip = open(objcDynamicFrameworksURL)
+
+# Get the swift dynamic frameworks (need to change this to the correct path before checking in)
+swiftDynamicFrameworksAsset = assets.find{ |asset|
+  asset[GitHubConstants::Name] == Filenames::SwiftDynamicFrameworks
+}
+swiftDynamicFrameworksURL = swiftDynamicFrameworksAsset[GitHubConstants::DownloadURL]
+swiftDynamicFrameworksZip = open(swiftDynamicFrameworksURL)
+
+# Renaming the Tempfile format provided by the `open` method to be human readable
+FileUtils.mv(objcDynamicFrameworksZip.path, Filenames::ObjcDynamicFrameworksZip)
+FileUtils.mv(swiftDynamicFrameworksZip.path, Filenames::SwiftDynamicFrameworksZip)
+
+# Extract objc dynamic frameworks
+Zip::File.open(Filenames::ObjcDynamicFrameworksZip) do |zip_file|
+  # Handle entries one by one
+  zip_file.each do |entry|
+    puts "Extracting #{entry.name}"
+    entry.extract("Artifacts/#{entry.name}")
+  end
+end
+
+# Extract swift dynamic frameworks
+Zip::File.open(Filenames::SwiftDynamicFrameworksZip) do |zip_file|
+  # Handle entries one by one
+  zip_file.each do |entry|
+    # Extract to file/directory/symlink
+    puts "Extracting #{entry.name}"
+    entry.extract("Artifacts/#{entry.name}")
+  end
+end
+
+system "zip -r -m Artifacts.zip Artifacts"
+system 'rm -rf Artifacts'
+system "mv Artifacts.zip build/Release/#{Filenames::DynamicFrameworks}"
+
+FileUtils.rm_f("Artifacts")
+FileUtils.rm_f(Filenames::ObjcDynamicFrameworksZip)
+FileUtils.rm_f(Filenames::SwiftDynamicFrameworksZip)


### PR DESCRIPTION
Thanks for proposing a pull request!

To help us review the request, please complete the following:

- [x] sign [contributor license agreement](https://developers.facebook.com/opensource/cla)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [x] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

* Adds dynamic targets for Swift-enabled kits
* Updates CI scripts to release Swift-enabled kits

## Test Plan

Test Plan: 
Will need to verify that this works as part of the next release but in the meantime you can change line 18 of `combineReleases.rb` to:  `SwiftDynamicFrameworks = 'FBSDKCoreKit-Swift.zip'` and run `./scripts/run.sh release github combine`

This will pull down `FacebookSDK_Dynamic.framework.zip` and `FBSDKCoreKit-Swift.zip` from the latest release, combine them and put the output in `build/Release/`. During CI this will be uploaded to Github and override the existing artifact named `FacebookSDK_Dynamic.framework.zip`. 

Locally you can verify that the `build/Release/FacebookSDK_Dynamic.framework.zip` contains dynamic frameworks for Swift and non-Swift build variants.

