### PR TITLE
Fix NSUnknownKeyException crash problem for tvOS 12.x and below.

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKInternalUtility.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKInternalUtility.m
@@ -496,7 +496,7 @@ static NSMapTable *_transientObjects;
   }
 
   // Find active key window from UIScene
-  if (@available(iOS 13.0, *)) {
+  if (@available(iOS 13.0, tvOS 13, *)) {
     NSSet *scenes = [[UIApplication sharedApplication] valueForKey:@"connectedScenes"];
     for (id scene in scenes) {
       if (window) {


### PR DESCRIPTION
Thanks for proposing a pull request!

To help us review the request, please complete the following:

- [x] sign [contributor license agreement](https://developers.facebook.com/opensource/cla)
- [x] describe the change (for example, what happens before the change, and after the change)

As the error states:
`Terminating app due to uncaught exception 'NSUnknownKeyException', reason: '[<UIApplication 0x7fb94af02a70> valueForUndefinedKey:]: this class is not key value coding-compliant for the key connectedScenes.'`

@available(iOS 13.0, *) should add tvOS 13.0, because it can not restrict tvOS version, and the UIWindowScene only support for iOS 13+, Mac Catalyst 13.0+, tvOS 13.0+.